### PR TITLE
Rewrite spec using bikeshed.

### DIFF
--- a/default.css
+++ b/default.css
@@ -1,0 +1,985 @@
+/* This section copied from the W3C's ED styles. */
+
+	body {
+		color: black;
+		font-family: sans-serif;
+		margin: 0 auto;
+		max-width: 50em;
+		padding: 2em 1em 2em 70px;
+	}
+	:link { color: #00C; background: transparent }
+	:visited { color: #609; background: transparent }
+	a[href]:active { color: #C00; background: transparent }
+	a[href]:hover { background: #ffa }
+
+	a[href] img { border-style: none }
+
+	h1, h2, h3, h4, h5, h6 { text-align: left }
+	h1, h2, h3 { color: #005A9C; }
+	h1 { font: 170% sans-serif }
+	h2 { font: 140% sans-serif }
+	h3 { font: 120% sans-serif }
+	h4 { font: bold 100% sans-serif }
+	h5 { font: italic 100% sans-serif }
+	h6 { font: small-caps 100% sans-serif }
+
+	.hide { display: none }
+
+	div.head { margin-bottom: 1em }
+	div.head h1 { margin-top: 2em; clear: both }
+	div.head table { margin-left: 2em; margin-top: 2em }
+
+	p.copyright { font-size: small }
+	p.copyright small { font-size: small }
+
+	pre { margin-left: 2em }
+	dt { font-weight: bold }
+
+	ul.toc, ol.toc {
+		list-style: none;
+	}
+
+/* The rest copied from the CSSWG's default.css */
+
+	body {
+		counter-reset: exampleno figure issue;
+		max-width: 50em;
+		margin: 0 auto !important;
+		line-height: 1.5;
+	}
+
+/******************************************************************************/
+/*                                Sectioning                                  */
+/******************************************************************************/
+
+/** Headings ******************************************************************/
+
+	h1, h2, h3, h4, h5, h6, dt {
+		page-break-after: avoid;
+	}
+
+	h2, h3, h5, h6 {
+		margin-top: 3em;
+	}
+	h4 {
+		 margin-top: 4em;
+	}
+
+/** Subheadings ***************************************************************/
+
+	h1 + h2,
+	#subtitle + h2 {
+		/* #subtitle is a subtitle in an H2 under the H1 */
+		margin-top: 0;
+	}
+	h2 + h3,
+	h3 + h4,
+	h4 + h5,
+	h5 + h6 {
+		margin-top: 1.2em; /* = 1 x line-height */
+	}
+
+/** Section divider ***********************************************************/
+	/* <hr> used to separate TMI into the second half of a section              */
+	hr:not([title]) {
+		font-size: 1.5em;
+		text-align: center;
+		margin: 1em auto;
+		height: auto;
+		border: transparent solid 0;
+		background: transparent;
+	}
+	hr:not([title])::before {
+		content: "\1F411\2003\2003\1F411\2003\2003\1F411";
+	}
+	/* note: <hr> with title separates document header from contents */
+
+/******************************************************************************/
+/*                            Paragraphs and Lists                            */
+/******************************************************************************/
+
+	p {
+		margin: 1em 0;
+	}
+	dd     > p:first-child,
+	li     > p:first-child {
+		margin-top: 0;
+	}
+
+	ul, ol {
+		margin-left: 0;
+		padding-left: 2em;
+	}
+	li {
+		margin: 0.25em 2em 0.5em 0;
+		padding-left: 0;
+	}
+
+	dl dd {
+		margin: 0 0 1em 2em;
+	}
+	.head dd {
+		margin-bottom: 0;
+	}
+
+	/* Style for algorithms */
+	ol.algorithm ol {
+	 border-left: 1px solid #90b8de;
+	 margin-left: 1em;
+	}
+	ol.algorithm ol.algorithm {
+	 border-left: none;
+	 margin-left: 0;
+	}
+
+	/* Style for switch/case <dl>s */
+	dl.switch > dd > ol.only {
+	 margin-left: 0;
+	}
+	dl.switch > dd > ol.algorithm {
+	 margin-left: -2em;
+	}
+	dl.switch {
+	 padding-left: 2em;
+	}
+	dl.switch > dt {
+	 text-indent: -1.5em;
+	 margin-top: 1em;
+	}
+	dl.switch > dt + dt {
+	 margin-top: 0;
+	}
+	dl.switch > dt::before {
+	 content: '\21AA';
+	 padding: 0 0.5em 0 0;
+	 display: inline-block;
+	 width: 1em;
+	 text-align: right;
+	 line-height: 0.5em;
+	}
+
+	/* Style for paragraphs I know are in MD-genned lists */
+	[data-md] > :first-child {
+		margin-top: 0;
+	}
+	[data-md] > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Inline Lists **************************************************************/
+	/* This is mostly to make the list inside the CR exit criteria more compact. */
+
+	ol.inline, ol.inline li {
+		display: inline;
+		padding: 0; margin: 0;
+	}
+	ol.inline {
+		counter-reset: list-item;
+	}
+	ol.inline li {
+		counter-increment: list-item;
+	}
+	ol.inline li::before {
+		content: "(" counter(list-item) ") ";
+		font-weight: bold;
+	}
+
+/** Terminology Markup ********************************************************/
+
+
+/******************************************************************************/
+/*                                 Inline Markup                              */
+/******************************************************************************/
+
+/** Terminology Markup ********************************************************/
+	dfn   { /* Defining instance */
+		font-weight: bolder;
+	}
+	a > i { /* Instance of term */
+		font-style: normal;
+	}
+	dt dfn code, code.idl {
+		font-size: inherit;
+	}
+	dfn var {
+		font-style: normal;
+	}
+
+/** Change Marking ************************************************************/
+
+	del { color: red;  text-decoration: line-through; }
+	ins { color: #080; text-decoration: underline;    }
+
+/** Miscellaneous improvements to inline formatting ***************************/
+
+	sup {
+		vertical-align: super;
+		font-size: 80%
+	}
+
+/******************************************************************************/
+/*                                    Code                                    */
+/******************************************************************************/
+
+/** General monospace/pre rules ***********************************************/
+
+	pre, code {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+		font-size: .9em;
+		page-break-inside: avoid;
+	}
+	pre {
+		margin-top: 1em;
+		margin-bottom: 1em;
+		overflow: auto;
+	}
+
+/** Syntax-Highlighted Code ***************************************************/
+
+	.example pre[class*="language-"],
+	.example [class*="language-"] pre,
+	.example pre[class*="lang-"],
+	.example [class*="lang-"] pre {
+		background: transparent; /* Prism applies a gray background that doesn't work well in the template. */
+	}
+
+/** Example Code **************************************************************/
+
+	div.html, div.xml,
+	pre.html, pre.xml {
+		padding: 0.5em;
+		margin: 1em 0;
+		position: relative;
+		clear: both;
+		color: #600;
+	}
+	pre.example,
+	pre.html,
+	pre.xml {
+		padding-top: 1.5em;
+	}
+
+	pre.illegal, .illegal pre
+	pre.deprecated, .deprecated pre {
+		color: red;
+	}
+
+/** IDL fragments *************************************************************/
+
+	pre.idl {
+		/* Match blue propdef boxes */
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+	}
+	pre.idl :link, pre.idl :visited {
+		color:inherit;
+		background:transparent;
+	}
+
+/** Inline CSS fragments ******************************************************/
+
+	.css.css, .property.property, .descriptor.descriptor {
+		color: #005a9c;
+		font-size: inherit;
+		font-family: inherit;
+	}
+	.css::before, .property::before, .descriptor::before {
+		content: "‘";
+	}
+	.css::after, .property::after, .descriptor::after {
+		content: "’";
+	}
+	.property, .descriptor {
+		/* Don't wrap property and descriptor names */
+		white-space: nowrap;
+	}
+	.type { /* CSS value <type> */
+	font-style: italic;
+	}
+	pre .property::before, pre .property::after {
+		content: "";
+	}
+
+/** Inline markup fragments ***************************************************/
+
+	code.html, code.xml {
+		color: #660000;
+	}
+
+/** Autolinks produced using Bikeshed *****************************************/
+
+	[data-link-type="property"]::before,
+	[data-link-type="propdesc"]::before,
+	[data-link-type="descriptor"]::before,
+	[data-link-type="value"]::before,
+	[data-link-type="function"]::before,
+	[data-link-type="at-rule"]::before,
+	[data-link-type="selector"]::before,
+	[data-link-type="maybe"]::before {
+		content: "‘";
+	}
+	[data-link-type="property"]::after,
+	[data-link-type="propdesc"]::after,
+	[data-link-type="descriptor"]::after,
+	[data-link-type="value"]::after,
+	[data-link-type="function"]::after,
+	[data-link-type="at-rule"]::after,
+	[data-link-type="selector"]::after,
+	[data-link-type="maybe"]::after {
+		content: "’";
+	}
+
+	[data-link-type].production::before,
+	[data-link-type].production::after,
+	.prod [data-link-type]::before,
+	.prod [data-link-type]::after {
+		content: "";
+	}
+
+	[data-link-type=element]         { font-family: monospace; }
+	[data-link-type=element]::before { content: "<" }
+	[data-link-type=element]::after  { content: ">" }
+
+	[data-link-type=biblio] {
+		white-space: pre;
+	}
+
+
+/******************************************************************************/
+/*                                    Links                                   */
+/******************************************************************************/
+
+/** General Hyperlinks ********************************************************/
+
+	/* We hyperlink a lot, so make it less intrusive */
+	a:link, a:visited {
+		color: inherit;
+		text-decoration: none;
+		border-bottom: 1px solid silver;
+	}
+	@supports (text-decoration-color: silver) {
+		a:link, a:visited {
+			border-bottom: none;
+			text-decoration: underline;
+			text-decoration-color: silver;
+		}
+		a:visited {
+			text-decoration-style: dotted;
+		}
+	}
+
+	a.logo:link, a.logo:visited { /* backout above styling for W3C logo */
+		padding: 0;
+		border: none;
+		text-decoration: none;
+	}
+
+/** Self-Links ****************************************************************/
+	/* Auto-generated links from an element to its own anchor, for usability */
+
+	.heading, .issue, .note, .example, li, dt {
+		position: relative;
+	}
+	a.self-link {
+		position: absolute;
+		top: 0;
+		left: -2.5em;
+		width: 2em;
+		height: 2em;
+		text-align: center;
+		border: none;
+		transition: opacity .2s;
+		opacity: .5;
+	}
+	a.self-link:hover {
+		opacity: 1;
+	}
+	.heading > a.self-link {
+		font-size: 83%;
+	}
+	li > a.self-link {
+		left: -3.5em;
+	}
+	dfn > a.self-link {
+		top: auto;
+		left: auto;
+		opacity: 0;
+		width: 1.5em;
+		height: 1.5em;
+		background: gray;
+		color: white;
+		font-style: normal;
+		transition: opacity .2s, background-color .2s, color .2s;
+	}
+	dfn:hover > a.self-link {
+		opacity: 1;
+	}
+	dfn > a.self-link:hover {
+		color: black;
+	}
+
+	a.self-link::before            { content: "¶"; }
+	.heading > a.self-link::before { content: "§"; }
+	dfn > a.self-link::before      { content: "#"; }
+
+/******************************************************************************/
+/*                                    Images                                  */
+/******************************************************************************/
+
+	img {
+		border-style: none;
+		color: white;
+	}
+
+	figure, div.figure, div.sidefigure {
+		page-break-inside: avoid;
+	}
+
+	div.figure, p.figure, div.sidefigure, figure {
+		text-align: center;
+		margin: 2.5em 0;
+	}
+	div.figure pre, div.sidefigure pre, figure pre {
+		text-align: left;
+		display: table;
+		margin: 1em auto;
+	}
+	.figure table, figure table {
+		margin: auto;
+	}
+	div.sidefigure, figure.sidefigure {
+		float: right;
+		width: 50%;
+		margin: 0 0 0.5em 0.5em
+	}
+	div.figure img, div.sidefigure img, figure img,
+	div.figure object, div.sidefigure object, figure object {
+		display: block;
+		margin: auto;
+		max-width: 100%
+	}
+	p.caption, figcaption, caption {
+		text-align: center;
+		font-style: italic;
+		font-size: 90%;
+	}
+	p.caption:not(.no-marker)::before, figcaption:not(.no-marker)::before {
+		content: "Figure " counter(figure) ". ";
+	}
+	p.caption::before, figcaption::before, figcaption > .marker {
+		font-weight: bold;
+	}
+	p.caption, figcaption {
+		counter-increment: figure;
+	}
+
+	/* DL list is indented 2em, but figure inside it is not */
+	dd > div.figure, dd > figure { margin-left: -2em }
+
+	pre.ascii-art {
+		display: table; /* shrinkwrap */
+		margin: 1em auto;
+	}
+
+	/* Displaying the output of text layout, particularly when
+		 line-breaking is being invoked, and thus having a
+		 visible width is good. */
+	pre.output {
+		margin: 1em;
+		border: solid thin silver;
+		padding: 0.25em;
+		display: table;
+	}
+
+/******************************************************************************/
+/*                             Colored Boxes                                  */
+/******************************************************************************/
+
+	.issue, .note, .example, .why, .advisement, blockquote {
+		padding: .5em;
+		border: .5em;
+		border-left-style: solid;
+		page-break-inside: avoid;
+	}
+	span.issue, span.note {
+		padding: .1em .5em .15em;
+		border-right-style: solid;
+	}
+
+	div.issue,
+	div.note,
+	div.example,
+	details.why,
+	blockquote {
+		margin: 1em auto;
+	}
+	.note  > p:first-child,
+	.issue > p:first-child,
+	blockquote > :first-child {
+		margin-top: 0;
+	}
+	blockquote > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Blockquotes ***************************************************************/
+
+	blockquote {
+		border-color: silver;
+	}
+
+/** Open issue ****************************************************************/
+	/* not intended for CR+ publication */
+
+	.issue {
+		border-color: #E05252;
+		background: #FBE9E9;
+		counter-increment: issue;
+		overflow: auto;
+	}
+	.issue:not(.no-marker)::before {
+		content: "ISSUE " counter(issue);
+		padding-right: 1em;
+	}
+	.issue::before, .issue > .marker {
+		color: #AE1E1E;
+	}
+
+/** Example *******************************************************************/
+
+	.example {
+		border-color: #E0CB52;
+		background: #FCFAEE;
+		counter-increment: exampleno;
+		overflow: auto;
+		clear: both;
+	}
+	.example::before, .example > .marker {
+		color: #827017;
+		font-family: sans-serif;
+		min-width: 7.5em;
+		display: block;
+	}
+	.example:not(.no-marker)::before {
+		content: "EXAMPLE";
+		content: "EXAMPLE " counter(exampleno);
+	}
+	.invalid.example::before, .invalid.example > .marker,
+	.illegal.example::before, .illegal.example > .marker {
+		color: red;
+	}
+	.invalid.example:not(.no-marker)::before,
+	.illegal.example:not(.no-marker)::before {
+		content: "INVALID EXAMPLE";
+		content: "INVALID EXAMPLE" counter(exampleno);
+	}
+
+/** Non-normative Note ********************************************************/
+
+	.note, .why {
+		border-color: #52E052;
+		background: #E9FBE9;
+		overflow: auto;
+	}
+	.note::before, .note > .marker {
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+
+/** Advisement Box ************************************************************/
+	/*  for attention-grabbing normative statements */
+
+	.advisement {
+		border-color: orange;
+		border-style: none solid;
+		background: #FFEECC;
+		text-align: center;
+	}
+	strong.advisement {
+		display: block;
+	}
+	/*.advisement::before { color: #FF8800; } */
+
+/** ??? ***********************************************************************/
+
+	details.why {
+		border-color: #52E052;
+		background: #E9FBE9;
+		display: block;
+	}
+
+	details.why > summary {
+		font-style: italic;
+		display: block;
+	}
+
+	details.why[open] > summary {
+		border-bottom: 1px silver solid;
+	}
+
+/** Spec Obsoletion Notice ****************************************************/
+	/* obnoxious obsoletion notice for older/abandoned specs. */
+
+	details.annoying-warning {
+		display: block;
+	}
+
+	details.annoying-warning[open] {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
+		text-align: center;
+		padding: .5em;
+		border: thick solid red;
+		border-radius: 1em;
+	}
+@media not print {
+	details.annoying-warning[open] {
+		position: fixed;
+		left: 1em;
+		right: 1em;
+		bottom: 1em;
+		z-index: 1000;
+	}
+}
+
+	details.annoying-warning:not([open]) > summary {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
+		text-align: center;
+		padding: .5em;
+	}
+
+/******************************************************************************/
+/*                                    Tables                                  */
+/******************************************************************************/
+
+/** Property/Descriptor Definition Tables *************************************/
+
+	table.propdef, table.propdef-extra,
+	table.descdef, table.definition-table {
+		page-break-inside: avoid;
+		width: 100%;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+		padding: 0.5em 1em;
+		background: #DEF;
+		border-spacing: 0;
+	}
+
+	table.propdef td, table.propdef-extra td,
+	table.descdef td, table.definition-table td,
+	table.propdef th, table.propdef-extra th,
+	table.descdef th, table.definition-table th {
+		padding: 0.5em;
+		vertical-align: baseline;
+		border-bottom: 1px solid #bbd7e9;
+	}
+	table.propdef > tbody > tr:last-child th,
+	table.propdef-extra > tbody > tr:last-child th,
+	table.descdef > tbody > tr:last-child th,
+	table.definition-table > tbody > tr:last-child th,
+	table.propdef > tbody > tr:last-child td,
+	table.propdef-extra > tbody > tr:last-child td,
+	table.descdef > tbody > tr:last-child td,
+	table.definition-table > tbody > tr:last-child td {
+		border-bottom: 0;
+	}
+
+	table.propdef th,
+	table.propdef-extra th,
+	table.descdef th,
+	table.definition-table th {
+		font-style: italic;
+		font-weight: normal;
+		width: 8.3em;
+		padding-left: 1em;
+	}
+
+	/* For when values are extra-complex and need formatting for readability */
+	table td.pre {
+		white-space: pre-wrap;
+	}
+
+	/* A footnote at the bottom of a propdef */
+	table.propdef td.footnote,
+	table.propdef-extra td.footnote,
+	table.descdef td.footnote,
+	table.definition-table td.footnote {
+		padding-top: 0.6em;
+	}
+	table.propdef td.footnote::before,
+	table.propdef-extra td.footnote::before,
+	table.descdef td.footnote::before,
+	table.definition-table td.footnote::before {
+		content: " ";
+		display: block;
+		height: 0.6em;
+		width: 4em;
+		border-top: thin solid;
+	}
+
+/** Profile Tables ************************************************************/
+	/* table of required features in a CSS profile */
+
+	table.features th {
+		background: #00589f;
+		color: #fff;
+		text-align: left;
+		padding: 0.2em 0.2em 0.2em 0.5em;
+	}
+	table.features td {
+		vertical-align: top;
+		border-bottom: 1px solid #ccc;
+		padding: 0.3em 0.3em 0.3em 0.7em;
+	}
+
+/** Data tables (and properly marked-up proptables) ***************************/
+	/*
+		 <table class="data"> highlights structural relationships in a table
+		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
+
+		 Use class="complex data" for particularly complicated tables --
+		 (This will draw more lines: busier, but clearer.)
+
+		 Use class="long" on table cells with paragraph-like contents
+		 (This will adjust text alignment accordingly.)
+	*/
+
+	.data, .proptable {
+		margin: 1em auto;
+		border-collapse: collapse;
+		width: 100%;
+		border: hidden;
+	}
+	.data {
+		text-align: center;
+		width: auto;
+	}
+	.data caption {
+		width: 100%;
+	}
+
+	.data td, .data th,
+	.proptable td, .proptable th {
+		padding: 0.5em;
+		border-width: 1px;
+		border-color: silver;
+		border-top-style: solid;
+	}
+
+	.data thead td:empty {
+		padding: 0;
+		border: 0;
+	}
+
+	.data thead th[scope="row"],
+	.proptable thead th[scope="row"] {
+		text-align: right;
+		color: inherit;
+	}
+
+	.data thead,
+	.proptable thead,
+	.data tbody,
+	.proptable tbody {
+		color: inherit;
+		border-bottom: 2px solid;
+	}
+
+	.data colgroup {
+		border-left: 2px solid;
+	}
+
+	.data tbody th:first-child,
+	.proptable tbody th:first-child ,
+	.data tbody td[scope="row"]:first-child,
+	.proptable tbody td[scope="row"]:first-child {
+		text-align: right;
+		color: inherit;
+		border-right: 2px solid;
+		border-top: 1px solid silver;
+		padding-right: 1em;
+	}
+	.data.define td:last-child {
+		text-align: left;
+	}
+
+	.data tbody th[rowspan],
+	.proptable tbody th[rowspan],
+	.data tbody td[rowspan],
+	.proptable tbody td[rowspan]{
+		border-left:  1px solid silver;
+		border-right: 1px solid silver;
+	}
+
+	.complex.data th,
+	.complex.data td {
+		border: 1px solid silver;
+	}
+
+	.data td.long {
+	 vertical-align: baseline;
+	 text-align: left;
+	}
+
+	.data img {
+		vertical-align: middle;
+	}
+
+
+/******************************************************************************/
+/*                                  Indices                                   */
+/******************************************************************************/
+
+
+/** Table of Contents *********************************************************/
+
+	/* ToC not indented, but font style shows hierarchy */
+	ul.toc           { margin: 1em 0;     font-weight: bold; /*text-transform: uppercase;*/ }
+	ul.toc ul        { margin: 0;        font-weight: normal; text-transform: none; }
+	ul.toc ul ul     { margin: 0 0 0 2em; font-style: italic; }
+	ul.toc ul ul ul  { margin: 0; }
+	ul.toc > li      { margin: 1.5em 0; }
+	ul.toc ul.toc li { margin: 0.3em 0 0 0; }
+
+	ul.toc, ul.toc ul, ul.toc li { padding: 0; line-height: 1.3; }
+	ul.toc a { text-decoration: none; border-bottom-style: none; }
+	ul.toc a:hover, ul.toc a:focus  { border-bottom-style: solid; }
+	@supports (text-decoration-style: solid) {
+		ul.toc a:hover, ul.toc a:focus  {
+			border-bottom-style: none;
+			text-decoration-style: solid;
+		}
+	}
+	/*
+	ul.toc li li li, ul.toc li li li ul {margin-left: 0; display: inline}
+	ul.toc li li li ul, ul.toc li li li ul li {margin-left: 0; display: inline}
+	*/
+
+	/* Section numbers in a column of their own */
+	ul.toc {
+		margin-left: 5em
+	}
+	ul.toc span.secno {
+		float: left;
+		width: 4em;
+		margin-left: -5em;
+	}
+	ul.toc ul ul span.secno {
+		margin-left: -7em;
+	}
+	/*ul.toc span.secno {text-align: right}*/
+	ul.toc li {
+		clear: both;
+	}
+	/* If we had 'tab', floats would not be needed here:
+		 ul.toc span.secno {tab: 5em right; margin-right: 1em}
+		 ul.toc li {text-indent: 5em hanging}
+	 The second line in case items wrap
+	*/
+
+/** At-risk List **************************************************************/
+	/* Style for At Risk features (intended as editorial aid, not intended for publishing) */
+
+	.atrisk::before {
+	 float: right;
+	 margin-top: -0.25em;
+	 padding: 0.5em 1em 0.5em 0;
+	 text-indent: -0.9em;
+	 border: 1px solid;
+	 content: '\25C0    Not yet widely implemented';
+	 white-space: pre;
+	 font-size: small;
+	 background-color: white;
+	 color: gray;
+	 text-align: center;
+	}
+
+	.toc .atrisk::before { content:none }
+
+/** Index *********************************************************************/
+
+	/* Index Lists: Layout */
+	ul.indexlist       { margin-left: 0; columns: 15em; -webkit-columns: 15em; text-indent: 1em hanging; }
+	ul.indexlist li    { margin-left: 0; list-style: none; break-inside: avoid; word-break: break-word; }
+	ul.indexlist li li { margin-left: 1em }
+	ul.indexlist dl    { margin-top: 0; }
+	ul.indexlist dt    { margin: .2em 0 .2em 20px;}
+	ul.indexlist dd    { margin: .2em 0 .2em 40px;}
+	/* Index Lists: Typography */
+	ul.indexlist ul,
+	ul.indexlist dl { font-size: smaller; }
+	ul.indexlist li span {
+		white-space: nowrap;
+		position: absolute;
+		color: transparent; }
+	ul.indexlist li a:hover + span,
+	ul.indexlist li a:focus + span {
+		color: gray;
+	}
+	@media print {
+		ul.indexlist li span { color: gray; }
+	}
+
+/** Property Index Tables *****************************************************/
+	/* See also the data table styling section, which this effectively subclasses */
+
+	table.proptable {
+		font-size: small;
+		border-collapse: collapse;
+		border-spacing: 0;
+		text-align: left;
+		margin: 1em 0;
+	}
+
+	table.proptable td,
+	table.proptable th {
+		padding: 0.4em;
+		text-align: center;
+	}
+
+	table.proptable tr:hover td {
+		background: #DEF;
+	}
+	.propdef th {
+		font-style: italic;
+		font-weight: normal;
+		text-align: left;
+		width: 3em;
+	}
+	/* The link in the first column in the property table (formerly a TD) */
+	table.proptable td .property,
+	table.proptable th .property {
+		display: block;
+		text-align: left;
+		font-weight: bold;
+	}
+
+/******************************************************************************/
+/*                                    Print                                   */
+/******************************************************************************/
+
+	@media print {
+		html {
+			margin: 0 !important; }
+		body {
+			font-family: serif; }
+		th, td {
+			font-family: inherit; }
+		a {
+			color: inherit !important; }
+
+		a:link, a:visited {
+			text-decoration: none !important }
+		a:link::after, a:visited::after { /* create a cross-ref "see..." */ }
+		.example::before {
+			font-family: serif !important; }
+	}
+	@page {
+		margin: 1.5cm 1.1cm;
+	}
+

--- a/spec/footer.include
+++ b/spec/footer.include
@@ -1,0 +1,33 @@
+</main>
+<h2 id="conformance" class="no-ref no-num">
+Conformance</h2>
+
+    <p>
+        Conformance requirements are expressed with a combination of descriptive assertions and RFC 2119 terminology.
+        The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+        in the normative parts of this document
+        are to be interpreted as described in RFC 2119.
+        However, for readability,
+        these words do not appear in all uppercase letters in this specification.
+
+    <p>
+        All of the text of this specification is normative
+        except sections explicitly marked as non-normative, examples, and notes. [[!RFC2119]]
+
+    <p>
+        Examples in this specification are introduced with the words “for example”
+        or are set apart from the normative text with <code>class="example"</code>, like this:
+
+    <div class="example">
+        This is an example of an informative example.
+    </div>
+
+    <p>
+        Informative notes begin with the word “Note”
+        and are set apart from the normative text with <code>class="note"</code>, like this:
+
+    <p class='note'>
+        Note, this is an informative note.
+
+</body>
+</html>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1,0 +1,404 @@
+<pre class='metadata'>
+Title: Web Background Synchronization
+Status: UD
+ED: https://slightlyoff.github.io/BackgroundSync/spec/
+Shortname: foreign-fetch
+Level: 1
+Editor: Josh Karlin, Google, jkarlin@chromium.org
+Editor: Marijn Kruisselbrink, Google, mek@chromium.org
+Abstract: This specification describes a method that enables web applications to synchronize data in the background.
+Group: personal
+Repository: slightlyoff/BackgroundSync
+Link Defaults: html (dfn) allowed to show a popup/event handler idl attribute/global object/in parallel/incumbent settings object/perform a microtask checkpoint/queue a task/script execution environment
+</pre>
+
+<pre class=biblio>
+{
+  "promises-guide": {
+    "href": "https://www.w3.org/2001/tag/doc/promises-guide",
+    "title": "Writing Promise-Using Specifications",
+    "date": "24 July 2015",
+    "status": "Finding of the W3C TAG",
+    "publisher": "W3C TAG"
+  }
+}
+</pre>
+
+<pre class="anchors">
+spec: ecma-262; urlPrefix: http://www.ecma-international.org/ecma-262/6.0/
+    type: dfn
+        text: Assert; url: sec-algorithm-conventions
+
+spec: html; urlPrefix: https://html.spec.whatwg.org/
+    type: dfn
+        text: trusted; url: concept-events-trusted
+
+spec: powerful-features; urlPrefix: https://w3c.github.io/webappsec/specs/powerfulfeatures/#
+    type: dfn
+        text: secure context; url: secure-context
+
+spec: promises-guide; urlPrefix: https://www.w3.org/2001/tag/doc/promises-guide#
+    type: dfn
+        text: A new promise; url: a-new-promise
+        text: A promise rejected with; url: a-promise-rejected-with
+        text: Reject; url: reject-promise
+        text: Resolve; url: resolve-promise
+        text: Transforming; url: transforming-by
+        text: Upon fulfillment; url: upon-fulfillment
+        text: Upon rejection; url: upon-rejection
+        text: Waiting for all; url: waiting-for-all
+
+spec: service-workers; urlPrefix: https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html
+    type: dfn
+        text: active worker; url: dfn-active-worker
+        text: client; url: dfn-service-worker-client
+        text: control; url: dfn-control
+        text: extended lifetime promises; url: dfn-extend-lifetime-promises
+        text: handle functional event; url: handle-functional-event-algorithm
+        text: service worker; url: service-worker-concept
+        text: service worker registration; url: service-worker-registration-concept
+        text: termination; url: terminate-service-worker-algorithm
+    type: interface
+        text: ExtendableEvent; url: extendable-event-interface
+        text: ExtendableEventInit; url: extendable-event-init-dictionary
+        text: ServiceWorkerGlobalScope; url: service-worker-global-scope-interface
+        text: ServiceWorkerRegistration; url: service-worker-registration-interface
+
+spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/#
+    type: exception
+        text: AbortError; url: aborterror
+        text: InvalidAccessError; url: invalidaccesserror
+        text: InvalidModificationError; url: invalidmodificationerror
+        text: NetworkError; url: networkerror
+        text: NotFoundError; url: notfounderror
+        text: NotSupportedError; url: notsupportederror
+        text: SecurityError; url: securityerror
+        text: SyntaxError; url: syntaxerror
+    type: interface
+        text: DOMString; url: idl-DOMString
+        text: sequence; url: idl-sequence
+</pre>
+
+<section>
+  <h2 id='introduction'>Introduction</h2>
+
+  <em>This section is non-normative.</em>
+
+  Web Applications often run in environments with unreliable networks (e.g., mobile phones) and unknown lifetimes (the browser might be killed or the user might navigate away). This makes it difficult to  synchronize client data from web apps (such as photo uploads, document changes, or composed emails) with servers. If the browser closes or the user navigates away before synchronization can complete, the app must wait until the user revisits the page to try again. This specification provides a new onsync <a>service worker</a> event which can fire <a>in the background</a> so that synchronization attempts can continue despite adverse conditions when initially requested. This API is intended to reduce the time between content creation and content synchronization with the server.
+
+  As this API relies on service workers, functionality provided by this API is only available in a <a>secure context</a>.
+</section>
+
+<section>
+  <h2 id="concepts">Concepts</h2>
+
+  The sync event is considered to run <dfn>in the background</dfn> if the user agent is either closed or no service worker clients (controlled or uncontrolled) exist for the corresponding service worker registration.
+</section>
+
+<section>
+  <h2 id="constructs">Constructs</h2>
+  A <a>service worker registration</a> has an associated <dfn>list of sync registrations</dfn> whose element type is a <a>sync registration</a>.
+
+  A <dfn>sync registration</dfn> is a tuple consisting of a <a>tag</a> and a <a lt="registration state">state</a>.
+
+  A <a>sync registration</a> has an associated <dfn>tag</dfn>, a string.
+
+  A <a>sync registration</a> has an associated <dfn>registration state</dfn>, which is one of <dfn>pending</dfn>, <dfn>firing</dfn>, <dfn>unregisteredWhileFiring</dfn>, <dfn>unregistered</dfn>, <dfn>success</dfn> or <dfn>failed</dfn>. It is initially set to <a>pending</a>.
+
+  A <a>sync registration</a> has an associated <a>service worker registration</a>. It is initially set to null.
+
+  A <a>registration state</a> is a <dfn>final registration state</dfn> if it is one of <a>unregistered</a>, <a>success</a>, or <a>failed</a>.
+
+  A <a>registration state</a> is a <dfn>firing registration state</dfn> if it is one of <a>firing</a> or <a>unregisteredWhileFiring</a>.
+
+  Within one <a>list of sync registrations</a> each <a>sync registration</a> MUST have a unique <a>tag</a>.
+</section>
+
+<section>
+  <h2 id="privacy-considerations">Privacy Considerations</h2>
+
+  <section>
+    <h3 id="location-tracking">Location Tracking</h3>
+    Fetch requests within the onsync event while <a>in the background</a> may reveal the client's IP address to the server after the user left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of sync events.
+  </section>
+
+  <section>
+    <h3 id="history-leaking">History Leaking</h3>
+    Fetch requests within the onsync event while <a>in the background</a> may reveal something about the client's navigation history to passive eavesdroppers. For instance, the client might visit site https://example.com, which registers a sync event, but doesn't fire until after the user has navigated away from the page and changed networks. Passive eavesdroppers on the new network may see the fetch requests that the onsync event makes. The fetch requests are HTTPS so the request contents will not be leaked but the domain may be (via DNS lookups and IP address of the request).
+
+    Issue: Nothing is limiting fetch requests to be HTTPS only.
+  </section>
+</section>
+
+<section>
+  <h2 id="api-description">API Description</h2>
+
+  <section>
+    <h3 id="service-worker-registration-extensions">Extensions to the {{ServiceWorkerRegistration}} interface</h3>
+
+    <pre class="idl">
+      partial interface ServiceWorkerRegistration {
+        readonly attribute SyncManager sync;
+      };
+    </pre>
+
+    The <code><dfn attribute for=SyncManager title=sync>sync</dfn></code> attribute exposes a {{SyncManager}}, which has an associated <a>service worker registration</a> represented by the {{ServiceWorkerRegistration}} on which the attribute is exposed.
+  </section>
+
+  <section>
+    <h3 id="sync-manager-interface">{{SyncManager}} interface</h3>
+
+    <pre class="idl">
+      [Exposed=(Window,Worker)]
+      interface SyncManager {
+        Promise&lt;SyncRegistration&gt; register(optional SyncRegistrationOptions options);
+        Promise&lt;SyncRegistration&gt; getRegistration(DOMString tag);
+        Promise&lt;sequence&lt;SyncRegistration&gt;&gt; getRegistrations();
+      };
+
+      dictionary SyncRegistrationOptions {
+        DOMString tag;
+      };
+    </pre>
+
+    The <code><dfn method for=SyncManager title="register(options)">register(<var>options</var>)</dfn></code> method, when invoked, MUST return <a>a new promise</a> <var>promise</var> and run the following steps <a>in parallel</a>:
+    <ol>
+      <li>
+        Let <var>serviceWorkerRegistration</var> be the {{SyncManager}}'s associated <a>service worker registration</a>.
+      </li>
+      <li>
+        If the <a>global object</a> specified by the <a>incumbent settings object</a> is a {{WorkerGlobalScope}} instance, and the <var>serviceWorkerRegistration</var>'s <a>active worker</a> is not currently <a lt="control">controlling</a> any <a>clients</a>, <a>reject</a> <var>promise</var> with an {{InvalidAccessError}} and abort these steps.
+      </li>
+      <li>
+        Let <var>currentRegistration</var> be the <a lt="sync registration">registration</a> in <var>serviceWorkerRegistration</var>'s <a>list of sync registrations</a> whose <a>tag</a> equals <var>options.tag</var> if it exists, else null.
+      </li>
+      <li>
+        If <var>currentRegistration</var> is not null, <a>resolve</a> <var>promise</var> with a new {{SyncRegistration>> instance associated with <var>currentRegistration</var> and abort these steps.
+      </li>
+      <li>
+        Let <var>newRegistration</var> be a new <a>sync registration</a>.
+      </li>
+      <li>
+        Set <var>newRegistration</var>'s associated <a>tag</a> to <var>options.tag</var>.
+      </li>
+      <li>
+        Set <var>newRegistration</var>'s associated <a>service worker registration</a> to <var>serviceWorkerRegistration</var>.
+      </li>
+      <li>
+        Add <var>newRegistration</var> to <var>serviceWorkerRegistration</var>'s <a>list of sync registrations</a>.
+      </li>
+      <li>
+        <a>Resolve</a> <var>promise</var> with a new {{SyncRegistration}} instance associated with <var>newRegistration</var>.
+      </li>
+    </ol>
+
+    The <code><dfn method for=SyncManager title="getRegistration(tag)">getRegistration(<var>tag</var>)</dfn></code> method when invoked, MUST return <a>a new promise</a> <var>promise</var> and run the following steps <a>in parallel</a>:
+    <ol>
+      <li>
+        Let <var>serviceWorkerRegistration</var> be the {{SyncManager}}'s associated <a>service worker registration</a>.
+      </li>
+      <li>
+        Let <var>currentRegistration</var> be the <a lt="sync registration">registration</a> in <var>serviceWorkerRegistration</var>'s <a>list of sync registrations</a> whose <a>tag</a> equals <var>options.tag</var> if it exists, else null.
+      </li>
+      <li>
+        If <var>currentRegistration</var> is null, <a>resolve</a> <var>promise</var> with null.
+      </li>
+      <li>
+        <a>Resolve</a> <var>promise</var> with a new {{SyncRegistration}} instance associated with <var>currentRegistration</var>.
+      </li>
+    </ol>
+
+    The <code><dfn method for=SyncManager title="getRegistrations()">getRegistrations()</dfn></code> method when invoked, MUST return <a>a new promise</a> <var>promise</var> and run the following steps <a>in parallel</a>:
+    <ol>
+      <li>
+        Let <var>serviceWorkerRegistration</var> be the {{SyncManager}}'s associated <a>service worker registration</a>.
+      </li>
+      <li>Let <var>currentRegistrations</var> be a new {{sequence}}.</li>
+      <li>
+        For each <var>registration</var> in <var>serviceWorkerRegistration</var>'s <a>list of sync registrations</a>, add a new {{SyncRegistration}} instance associated with <var>registration</var> to <var>currentRegistrations</var>.
+      </li>
+      <li>
+        <a>Resolve</a> <var>promise</var> with <var>currentRegistrations</var>.
+      </li>
+    </ol>
+
+    Issue: Should register/getRegistration/getRegistrations return a new SyncRegistration instance each time, or should it attempt to return the same instance if called from a context where it had already returned a particular registration?
+  </section>
+
+  <section>
+    <h3 id="sync-registration-interface">{{SyncRegistration}} interface</h3>
+
+    <pre class="idl">
+      [Exposed=(Window,Worker)]
+      interface SyncRegistration {
+        readonly attribute DOMString tag;
+        readonly attribute Promise&lt;boolean&gt; done;
+        Promise&lt;boolean&gt; unregister();
+      };
+    </pre>
+
+    <div class="note" heading="SyncRegistration members">
+      The {{SyncRegistration/tag}} attribute exposes the tag provided in options during registration.
+
+      The {{SyncRegistration/done}} attribute returns a promise which will resolve as soon as the service worker has finished handling a sync event. It resolves to true if the event was handled succesfully, and resolves to false if something went wrong.
+
+      The {{SyncRegistration/unregister()}} method can be called to unregister the sync registration.
+    </div>
+
+    A {{SyncRegistration}} instance has an associated <a>sync registration</a>.
+
+    A {{SyncRegistration}} instance has an associated <dfn>done promise</dfn>, a promise. It is initially set to null.
+
+    The <code><dfn attribute for=SyncRegistration title=tag>tag</dfn></code> attribute MUST return the <a>tag</a> of the associated <a>sync registration</a>.
+
+    The <code><dfn attribute for=SyncRegistration title=done>done</dfn></code> attribute MUST return the result of running the following steps:
+    <ol>
+      <li>
+        If the {{SyncRegistration}}'s <a>done promise</a> is null, then:
+        <ol>
+          <li>
+            Let <var>promise</var> be <a>a new promise</a>.
+          </li>
+          <li>
+            Set the {{SyncRegistration}}'s <a>done promise</a> to <var>promise</var>.
+          </li>
+          <li>
+            <a>In parallel</a>, when/if the <a>sync registration</a>'s <a>registration state</a> becomes a <a>final registration state</a>, run the following steps:
+            <ol>
+              <li>
+                If the <a>sync registrations</a>'s <a>registration state</a> is <a>success</a>, <a>resolve</a> <var>promise</var> with true, else <a>resolve</a> <var>promise</var> with false.
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+      <li>
+        Return {{SyncRegistration}}'s <a>done promise</a>.
+      </li>
+    </ol>
+
+    The <code><dfn method for=SyncRegistration title="unregister()">unregister()</dfn></code> method when invoked, MUST return <a>a new promise</a> <var>promise</var> and run the following steps <a>in parallel</a>:
+    <ol>
+      <li>
+        If this <a>sync registration</a> is not currently in the <a>list of sync registrations</a> associated with this <a>sync registration</a>'s <a>service worker registration</a>, <a>resolve</a> <var>promise</var> with false and abort these steps.
+      </li>
+      <li>
+        If the <a>sync registration</a>'s <a>registration state</a> is a <a>firing registration state</a>, set its <a lt="registration state">state</a> to <a>unregisteredWhileFiring</a>, else set its <a lt="registration state">state</a> to <a>unregistered</a>.
+      </li>
+      <li>
+        Remove this <a>sync registration</a> from the <a>list of sync registrations</a> associated with this <a>sync registration</a>'s <a>service worker registration</a>.
+      </li>
+      <li>
+        <a>Resolve</a> <var>promise</var> with true.
+      </li>
+    </ol>
+  </section>
+
+  <section>
+    <h3 id="sync-event">The <dfn>sync</dfn> event</h3>
+
+    <pre class="idl">
+      partial interface ServiceWorkerGlobalScope {
+        attribute EventHandler onsync;
+      };
+
+      [Constructor(DOMString type, SyncEventInit init), Exposed=ServiceWorker]
+      interface SyncEvent : ExtendableEvent {
+        readonly attribute SyncRegistration registration;
+      };
+
+      dictionary SyncEventInit : ExtendableEventInit {
+        required SyncRegistration registration;
+      };
+    </pre>
+
+    Note: The {{SyncEvent}} interface represents a firing sync registration. If the page (or worker) that registered the event is running, the user agent should fire the sync event as soon as network connectivity is available. Otherwise, the user agent should run at the soonest convenience. If the user agent decides to retry a failed event, it may retry at a time of its choosing.
+
+    Issue: More formally spec when a sync event should be fired.
+
+    To <dfn>fire a sync event</dfn> for a <a>sync registration</a> <var>registration</var>, the user agent MUST run the following steps:
+    <ol>
+      <li>
+        <a>Assert</a>: <var>registration</var>'s <a>registration state</a> is <a>pending</a>.
+      </li>
+      <li>
+        Let <var>serviceWorkerRegistration</var> be the <a>service worker registration</a> associated with <var>registration</var>.
+      </li>
+      <li>
+        <a>Assert</a>: <var>registration</var> exists in the <a>list of sync registrations</a> associated with <var>serviceWorkerRegistration</var>.
+      </li>
+      <li>
+        Set <var>registration</var>'s <a>registration state</a> to <a>firing</a>.
+      </li>
+      <li>
+        Invoke the <a>Handle Functional Event</a> algorithm with <var>registration</var> and the following substeps as arguments.
+        <ol>
+          <li>
+            Let <var>globalObject</var> be the <a>global object</a> these steps are called with.
+          </li>
+          <li>
+            Create a <a>trusted</a> event <var>e</var> that uses the {{SyncEvent}} interface, with the event type <a>sync</a>, which does not bubble and has no default action.
+          </li>
+          <li>
+            Let the {{SyncEvent/registration}} attribute of <var>e</var> be initialized to a new {{SyncRegistration}} associated with <var>registration</var>.
+          </li>
+          <li>
+            Dispatch <var>e</var> at <var>globalObject</var>.
+          </li>
+          <li>
+            Let <var>waitUntilPromise</var> be the result of <a>waiting for all</a> of <var>e</var>'s <a>extended lifetime promises</a>.
+          </li>
+          <li>
+            <a>Upon fulfillment</a> of <var>waitUntilPromise</var>, perform the following steps <a>in parallel</a>:
+            <ol>
+              <li>
+                Remove <var>registration</var> from <var>serviceWorkerRegistration</var>'s <a>list of sync registration</a>, if <var>registration</var> is still in that list.
+              </li>
+              <li>
+                Set <var>registration</var>'s <a>registration state</a> to <a>success</a>.
+              </li>
+            </ol>
+          </li>
+          <li>
+            <a>Upon fulfillment</a> of <var>waitUntilPromise</var>, or if the script has been aborted by the <a>termination</a> of the <a>service worker</a>, perform the following steps <a>in parallel</a>:
+            <ol>
+              <li>
+                If <var>registration</var>'s <a>registration state</a> is <a>unregisteredWhileFiring</a>:
+                <ol>
+                  <li>
+                    If <var>e</var> <a>should be retried</a>, set <var>registration</var>'s <a>registration state</a> to <a>unregistered</a>.
+                  </li>
+                  <li>
+                    Else set <var>registration</var>'s <a>registration state</a> to <a>failed</a>.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                Else:
+                <ol>
+                  <li>
+                    If <var>e</var> <a>should be retried</a>, set <var>registration</var>'s <a>registration state</a> to <a>pending</a>.
+                  </li>
+                  <li>
+                    Else:
+                    <ol>
+                      <li>
+                        Remove <var>registration</var> from <var>serviceWorkerRegistration</var>'s <a>list of sync registration</a>.
+                      </li>
+                      <li>
+                        Set <var>registration</var>'s <a>registration state</a> to <a>failed</a>.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+    </ol>
+
+    A <a href="#sync-event">sync event</a> <dfn>should be retried</dfn> based on some user agent defined heuristics.
+
+    Issue: retry behavior should probably be specced a bit better.
+</section>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12,6 +12,11 @@ Repository: slightlyoff/BackgroundSync
 Link Defaults: html (dfn) allowed to show a popup/event handler idl attribute/global object/in parallel/incumbent settings object/perform a microtask checkpoint/queue a task/script execution environment
 </pre>
 
+<p boilerplate='copyright'>
+  <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2015 the Contributors to the Web Background Synchronization Specification , published under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+  A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
+</p>
+
 <pre class=biblio>
 {
   "promises-guide": {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -360,7 +360,7 @@ spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/#
             </ol>
           </li>
           <li>
-            <a>Upon fulfillment</a> of <var>waitUntilPromise</var>, or if the script has been aborted by the <a>termination</a> of the <a>service worker</a>, perform the following steps <a>in parallel</a>:
+            <a>Upon rejection</a> of <var>waitUntilPromise</var>, or if the script has been aborted by the <a>termination</a> of the <a>service worker</a>, perform the following steps <a>in parallel</a>:
             <ol>
               <li>
                 If <var>registration</var>'s <a>registration state</a> is <a>unregisteredWhileFiring</a>:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -130,8 +130,6 @@ spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/#
   <section>
     <h3 id="history-leaking">History Leaking</h3>
     Fetch requests within the onsync event while <a>in the background</a> may reveal something about the client's navigation history to passive eavesdroppers. For instance, the client might visit site https://example.com, which registers a sync event, but doesn't fire until after the user has navigated away from the page and changed networks. Passive eavesdroppers on the new network may see the fetch requests that the onsync event makes. The fetch requests are HTTPS so the request contents will not be leaked but the domain may be (via DNS lookups and IP address of the request).
-
-    Issue: Nothing is limiting fetch requests to be HTTPS only.
   </section>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -64,12 +64,8 @@
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright 
-and related or neighboring rights to this work. 
-In addition, as of 23 September 2015, 
-the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
-which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
-Parts of this work may be from an existing specification document.  If so, those parts are instead covered by the license of the existing specification document. </p>
+   <p class="copyright" data-fill-with="copyright"> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2015 the Contributors to the Web Background Synchronization Specification , published under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+  A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1,375 +1,503 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <title>Web Background Synchronization</title>
-  <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-  <script
-    src="assets/web-spec-framework/bower_components/platform/platform.js">
-  </script>
-  <link rel="import" href="assets/web-spec-framework/framework.html">
-  <!-- <meta name="bug.blocked" content="14968"> -->
-  <meta name="bug.short_desc" content="[BackgroundSync]: ">
-<!-- <meta name="bug.product" content="WebAppsWG"> -->
-  <meta name="bug.component" content="BackgroundSync">
-</head>
-<body>
+  <link href="../default.css" rel="stylesheet" type="text/css">
+<style>
+  body {
+    background: url("https://www.w3.org/StyleSheets/TR/logo-unofficial.png") top left no-repeat white;
+    background-attachment: fixed;
+    color: black;
+    font-family: sans-serif;
+    margin: 0 auto;
+    max-width: 50em;
+    padding: 2em 1em 2em 70px;
+  }
+  :link { color: #00C; background: transparent }
+  :visited { color: #609; background: transparent }
+  a[href]:active { color: #C00; background: transparent }
+  a[href]:hover { background: #ffa }
 
-<div class="head">
-<!--  <div class="logo">
-    <a href="//www.w3.org/"><img width="72" height="48" src="//www.w3.org/Icons/w3c_home" alt="W3C"></a>
+  a[href] img { border-style: none }
+
+  h1, h2, h3, h4, h5, h6 { text-align: left }
+  h1, h2, h3 { color: #005A9C; }
+  h1 { font: 170% sans-serif }
+  h2 { font: 140% sans-serif }
+  h3 { font: 120% sans-serif }
+  h4 { font: bold 100% sans-serif }
+  h5 { font: italic 100% sans-serif }
+  h6 { font: small-caps 100% sans-serif }
+
+  .hide { display: none }
+
+  div.head { margin-bottom: 1em }
+  div.head h1 { margin-top: 2em; clear: both }
+  div.head table { margin-left: 2em; margin-top: 2em }
+
+  p.copyright { font-size: small }
+  p.copyright small { font-size: small }
+
+  pre { margin-left: 2em }
+  dt { font-weight: bold }
+
+  ul.toc, ol.toc {
+    list-style: none;
+  }
+  </style>
+  <meta content="Bikeshed 1.0.0" name="generator">
+ </head>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">Web Background Synchronization</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2015-09-22">22 September 2015</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="https://slightlyoff.github.io/BackgroundSync/spec/">https://slightlyoff.github.io/BackgroundSync/spec/</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/slightlyoff/BackgroundSync/issues/">GitHub</a>
+     <dt class="editor">Editors:
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:jkarlin@chromium.org">Josh Karlin</a> (<span class="p-org org">Google</span>)
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:mek@chromium.org">Marijn Kruisselbrink</a> (<span class="p-org org">Google</span>)
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright 
+and related or neighboring rights to this work. 
+In addition, as of 22 September 2015, 
+the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
+which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
+Parts of this work may be from an existing specification document.  If so, those parts are instead covered by the license of the existing specification document. </p>
+   <hr title="Separator for header">
   </div>
--->
-  <h1>Web Background Synchronization</h1>
-<!--  <h2 id="editors-draft">W3C Editor's Draft</h2> -->
-  <dl>
-  <dt>This version</dt>
-    <dd><a href="https://github.com/slightlyoff/BackgroundSync/tree/master/spec/index.html">https://github.com/slightlyoff/BackgroundSync/tree/master/spec/index.html</a></dd>
-  <dt>Latest editor's draft</dt>
-    <dd><a href="https://github.com/slightlyoff/BackgroundSync/tree/master/spec/index.html">https://github.com/slightlyoff/BackgroundSync/tree/master/spec/index.html</a></dd>
-  <dt>Previous version</dt>
-<!--    <dd><a href="http://www.w3.org/TR/background-synchronization/">http://www.w3.org/TR/background-synchronization/</a></dd> -->
-  <dt>Revision history</dt>
-    <dd><a id="log" href="https://github.com/slightlyoff/BackgroundSync/commits/master">https://github.com/slightlyoff/BackgroundSync/commits/master</a></dd>
-  <dt>Participate</dt>
-<!--    <dd>Discuss on <a href="http://lists.w3.org/Archives/Public/public-webapps/">public-webapps@w3.org</a> (<a href="http://www.w3.org/2008/webapps/">Web Applications Working Group</a>)</dd> -->
-    <dd><a href="https://github.com/slightlyoff/BackgroundSync/issues">File bugs</a></dd>
-  <dt>Editors</dt>
-    <dd class="vcard"><span class="fn">Josh Karlin</span>, <span class="org">Google</span>, &lt;<a class="email" href="mailto:jkarlin@chromium.org">jkarlin@chromium.org</a>&gt;</dd>
-  </dl>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>This specification describes a method that enables web applications to synchronize data in the background.</p>
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This is an unofficial draft.
+	It is provided for discussion only and may change at any moment.
+	Its publication here does not imply endorsement of its contents by W3C. 
+	Don’t cite this document other than as work in progress. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#concepts"><span class="secno">2</span> <span class="content">Concepts</span></a>
+    <li><a href="#constructs"><span class="secno">3</span> <span class="content">Constructs</span></a>
+    <li>
+     <a href="#privacy-considerations"><span class="secno">4</span> <span class="content">Privacy Considerations</span></a>
+     <ul class="toc">
+      <li><a href="#location-tracking"><span class="secno">4.1</span> <span class="content">Location Tracking</span></a>
+      <li><a href="#history-leaking"><span class="secno">4.2</span> <span class="content">History Leaking</span></a>
+     </ul>
+    <li>
+     <a href="#api-description"><span class="secno">5</span> <span class="content">API Description</span></a>
+     <ul class="toc">
+      <li><a href="#service-worker-registration-extensions"><span class="secno">5.1</span> <span class="content">Extensions to the <code class="idl"><span>ServiceWorkerRegistration</span></code> interface</span></a>
+      <li><a href="#sync-manager-interface"><span class="secno">5.2</span> <span class="content"><code class="idl"><span>SyncManager</span></code> interface</span></a>
+      <li><a href="#sync-registration-interface"><span class="secno">5.3</span> <span class="content"><code class="idl"><span>SyncRegistration</span></code> interface</span></a>
+      <li><a href="#sync-event"><span class="secno">5.4</span> <span class="content">The <span>sync</span> event</span></a>
+     </ul>
+    <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ul class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ul>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ul class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+     </ul>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
+   </ul>
+  </div>
+  <main>
+   <section>
+    <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+    <p><em>This section is non-normative.</em></p>
+    <p>Web Applications often run in environments with unreliable networks (e.g., mobile phones) and unknown lifetimes (the browser might be killed or the user might navigate away). This makes it difficult to  synchronize client data from web apps (such as photo uploads, document changes, or composed emails) with servers. If the browser closes or the user navigates away before synchronization can complete, the app must wait until the user revisits the page to try again. This specification provides a new onsync <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept">service worker</a> event which can fire <a data-link-type="dfn" href="#in-the-background">in the background</a> so that synchronization attempts can continue despite adverse conditions when initially requested. This API is intended to reduce the time between content creation and content synchronization with the server.</p>
+    <p>As this API relies on service workers, functionality provided by this API is only available in a <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">secure context</a>.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="2" id="concepts"><span class="secno">2. </span><span class="content">Concepts</span><a class="self-link" href="#concepts"></a></h2>
+    <p>The sync event is considered to run <dfn data-dfn-type="dfn" data-noexport="" id="in-the-background">in the background<a class="self-link" href="#in-the-background"></a></dfn> if the user agent is either closed or no service worker clients (controlled or uncontrolled) exist for the corresponding service worker registration.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="3" id="constructs"><span class="secno">3. </span><span class="content">Constructs</span><a class="self-link" href="#constructs"></a></h2>
+     A <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="list-of-sync-registrations">list of sync registrations<a class="self-link" href="#list-of-sync-registrations"></a></dfn> whose element type is a <a data-link-type="dfn" href="#sync-registration">sync registration</a>. 
+    <p>A <dfn data-dfn-type="dfn" data-noexport="" id="sync-registration">sync registration<a class="self-link" href="#sync-registration"></a></dfn> is a tuple consisting of a <a data-link-type="dfn" href="#tag">tag</a> and a <a data-link-type="dfn" href="#registration-state">state</a>.</p>
+    <p>A <a data-link-type="dfn" href="#sync-registration">sync registration</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="tag">tag<a class="self-link" href="#tag"></a></dfn>, a string.</p>
+    <p>A <a data-link-type="dfn" href="#sync-registration">sync registration</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="registration-state">registration state<a class="self-link" href="#registration-state"></a></dfn>, which is one of <dfn data-dfn-type="dfn" data-noexport="" id="pending">pending<a class="self-link" href="#pending"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="firing">firing<a class="self-link" href="#firing"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="unregisteredwhilefiring">unregisteredWhileFiring<a class="self-link" href="#unregisteredwhilefiring"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="unregistered">unregistered<a class="self-link" href="#unregistered"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="success">success<a class="self-link" href="#success"></a></dfn> or <dfn data-dfn-type="dfn" data-noexport="" id="failed">failed<a class="self-link" href="#failed"></a></dfn>. It is initially set to <a data-link-type="dfn" href="#pending">pending</a>.</p>
+    <p>A <a data-link-type="dfn" href="#sync-registration">sync registration</a> has an associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a>. It is initially set to null.</p>
+    <p>A <a data-link-type="dfn" href="#registration-state">registration state</a> is a <dfn data-dfn-type="dfn" data-noexport="" id="final-registration-state">final registration state<a class="self-link" href="#final-registration-state"></a></dfn> if it is one of <a data-link-type="dfn" href="#unregistered">unregistered</a>, <a data-link-type="dfn" href="#success">success</a>, or <a data-link-type="dfn" href="#failed">failed</a>.</p>
+    <p>A <a data-link-type="dfn" href="#registration-state">registration state</a> is a <dfn data-dfn-type="dfn" data-noexport="" id="firing-registration-state">firing registration state<a class="self-link" href="#firing-registration-state"></a></dfn> if it is one of <a data-link-type="dfn" href="#firing">firing</a> or <a data-link-type="dfn" href="#unregisteredwhilefiring">unregisteredWhileFiring</a>.</p>
+    <p>Within one <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registrations</a> each <a data-link-type="dfn" href="#sync-registration">sync registration</a> MUST have a unique <a data-link-type="dfn" href="#tag">tag</a>.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="4" id="privacy-considerations"><span class="secno">4. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy-considerations"></a></h2>
+    <section>
+     <h3 class="heading settled" data-level="4.1" id="location-tracking"><span class="secno">4.1. </span><span class="content">Location Tracking</span><a class="self-link" href="#location-tracking"></a></h3>
+      Fetch requests within the onsync event while <a data-link-type="dfn" href="#in-the-background">in the background</a> may reveal the client’s IP address to the server after the user left the page. The user agent SHOULD limit tracking by capping the number of retries and duration of sync events. 
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="4.2" id="history-leaking"><span class="secno">4.2. </span><span class="content">History Leaking</span><a class="self-link" href="#history-leaking"></a></h3>
+      Fetch requests within the onsync event while <a data-link-type="dfn" href="#in-the-background">in the background</a> may reveal something about the client’s navigation history to passive eavesdroppers. For instance, the client might visit site https://example.com, which registers a sync event, but doesn’t fire until after the user has navigated away from the page and changed networks. Passive eavesdroppers on the new network may see the fetch requests that the onsync event makes. The fetch requests are HTTPS so the request contents will not be leaked but the domain may be (via DNS lookups and IP address of the request). 
+     <p class="issue" id="issue-9a916108"><a class="self-link" href="#issue-9a916108"></a> Nothing is limiting fetch requests to be HTTPS only.</p>
+    </section>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="5" id="api-description"><span class="secno">5. </span><span class="content">API Description</span><a class="self-link" href="#api-description"></a></h2>
+    <section>
+     <h3 class="heading settled" data-level="5.1" id="service-worker-registration-extensions"><span class="secno">5.1. </span><span class="content">Extensions to the <code class="idl"><a data-link-type="idl" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface">ServiceWorkerRegistration</a></code> interface</span><a class="self-link" href="#service-worker-registration-extensions"></a></h3>
+<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface">ServiceWorkerRegistration</a> {
+  readonly attribute <a data-link-type="idl-name" href="#syncmanager">SyncManager</a> <dfn class="idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" data-readonly="" data-type="SyncManager " id="dom-serviceworkerregistration-sync">sync<a class="self-link" href="#dom-serviceworkerregistration-sync"></a></dfn>;
+};
+</pre>
+     <p>The <code><dfn class="idl-code" data-dfn-for="SyncManager" data-dfn-type="attribute" data-export="" id="dom-syncmanager-sync" title="sync">sync<a class="self-link" href="#dom-syncmanager-sync"></a></dfn></code> attribute exposes a <code class="idl"><a data-link-type="idl" href="#syncmanager">SyncManager</a></code>, which has an associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a> represented by the <code class="idl"><a data-link-type="idl" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface">ServiceWorkerRegistration</a></code> on which the attribute is exposed.</p>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="5.2" id="sync-manager-interface"><span class="secno">5.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#syncmanager">SyncManager</a></code> interface</span><a class="self-link" href="#sync-manager-interface"></a></h3>
+<pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="syncmanager">SyncManager<a class="self-link" href="#syncmanager"></a></dfn> {
+  Promise&lt;<a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-register">register</a>(optional <a data-link-type="idl-name" href="#dictdef-syncregistrationoptions">SyncRegistrationOptions</a> <dfn class="idl-code" data-dfn-for="SyncManager/register(options), SyncManager/register()" data-dfn-type="argument" data-export="" id="dom-syncmanager-register-options-options">options<a class="self-link" href="#dom-syncmanager-register-options-options"></a></dfn>);
+  Promise&lt;<a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-getregistration">getRegistration</a>(DOMString <dfn class="idl-code" data-dfn-for="SyncManager/getRegistration(tag)" data-dfn-type="argument" data-export="" id="dom-syncmanager-getregistration-tag-tag">tag<a class="self-link" href="#dom-syncmanager-getregistration-tag-tag"></a></dfn>);
+  Promise&lt;sequence&lt;<a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a>>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-getregistrations">getRegistrations</a>();
+};
 
-<!--
-  <p class="copyright">
-    <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&copy;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
-  </p>
--->
-  <hr>
-
-  <h2 id="abstract">Abstract</h2>
-
-  <p>This specification describes a method that enables web applications to synchronize data in the background.</p>
-
-<!--
-  <h2 id="status">Status of This Document</h2>
-
-  <p><em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em></p>
-
-  <p>This document was published by the <a href="http://www.w3.org/2008/webapps/">Web Applications Working Group</a> as an Editor's Draft. If you wish to make comments regarding this document, please send them to <a href="mailto:public-webapps@w3.org">public-webapps@w3.org</a> (<a href="mailto:public-webapps-request@w3.org?subject=subscribe">subscribe</a>, <a href="http://lists.w3.org/Archives/Public/public-webapps/">archives</a>). All feedback is welcome.</p><p>Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
-
-  <p>This document was produced by a group operating under the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/45559/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.</p>
-  -->
-
-</div>
-
-<spec-toc></spec-toc>
-
-<spec-clause id="introduction">
-  <h1>Introduction</h1>
-
-  <spec-section id="about">
-    <h1>About this Document</h1>
-
-    <p>All diagrams, examples, notes, are non-normative, as well as sections explicitly marked as non-normative. Everything else in this specification is normative.</p>
-
-    <p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this document are to be interpreted as described in <a href="http://dev.w3.org/2006/xbl2/#refsRFC2119">RFC2119</a>. For readability, these words do not appear in all uppercase letters in this specification.</p>
-
-    <p>Any point, at which a conforming UA must make decisions about the state or reaction to the state of the conceptual model, is captured as <a href="http://en.wikipedia.org/wiki/Algorithm">algorithm</a>. The algorithms are defined in terms of processing equivalence. The <dfn id="dfn-processing-equivalence">processing equivalence</dfn> is a constraint imposed on the algorithm implementors, requiring the output of the both UA-implemented and the specified algorithm to be exactly the same for all inputs.</p>
-  </spec-section>
-
-  <spec-section id="dependencies">
-    <h1>Dependencies</h1>
-
-    <p>This document relies on the following specifications:</p>
-
-    <ul>
-      <li><a href="http://www.w3.org/TR/service-workers/">Service Workers</a></li>
-      <li><a href="http://fetch.spec.whatwg.org/">Fetch Living Standard</a></li>
-      <li><a href="http://dom.spec.whatwg.org/">DOM Living Standard</a></li>
-      <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/">HTML Living Standard</a></li>
-      <li><a href="http://ecma-international.org/ecma-262/5.1/">ECMAScript Language Specification</a></li>
-      <li><a href="http://www.w3.org/TR/WebIDL/">Web IDL</a></li>
-      <li><a href="http://www.w3.org/TR/IndexedDB/">Indexed DB</a></li>
-      <li><a href="http://tools.ietf.org/html/rfc6454">The Web Origin Concept</a></li>
-    </ul>
-  </spec-section>
-
-  <spec-section class="informative" id="motivations">
-    <h1>Motivation</h1>
-
-    <p>Web Applications often run in environments with unreliable networks (e.g., mobile phones) and unknown lifetimes (the browser might be killed or the user might navigate away). This makes it difficult to  synchronize client data from web apps (such as photo uploads, document changes, or composed emails) with servers. If the browser closes or the user navigates away before synchronization can complete, the app must wait until the user revisits the page to try again. This specification provides a new onsync <a href="http://github.com/slightlyoff/ServiceWorker/">service worker</a> event which can fire <a href="#dfn-in-the-background">in the background</a> so that synchronization attempts can continue despite adverse conditions when initially requested. This API is intended to reduce the time between content creation and content synchronization with the server.</p>
-  </spec-section>
-
-</spec-clause>
-
-<spec-clause id="background-sync-concepts">
-  <h1>Concepts</h1>
-    <spec-section id="webapp">
-      <h1>Webapp</h1>
-      <p>The term <dfn id="dfn-webapp">webapp</dfn> refers to a Web application, i.e. an application implemented using Web technologies, and executing within the context of a Web <a href="#dfn-user-agent">user agent</a>, e.g. a Web browser or other Web runtime environment.</p>
-
-      <p>The term application server refers to server-side components of a webapp.</p>
-    </spec-section>
-
-  <spec-section id="background">
-    <h1>Background</h1>
-    <p>The sync event is considered to run <dfn id="dfn-in-the-background"> in the background</dfn> if the <a href="#dfn-user-agent">user agent</a> is either closed or no service worker clients (controlled or uncontrolled) exist for the corresponding service worker registration.</p>
-  </spec-section>
-
-  <spec-section id="registration-state">
-    <h1>Registration state</h1>
-    <p>A value of either pending, firing, unregisteredWhileFiring, unregistered, success, or failed.</p>
-  </spec-section>
-
-  <spec-section id="final-registration-state">
-    <h1>Final registration state</h1>
-    <p>A <a href="#def-registration-state">registration state</a> that is one of unregistered, success, or failed.</p>
-  </spec-section>
-
-  <spec-section id="firing">
-    <h1>Firing registration state</h1>
-    <p>A <a href="#def-firing-registration-state">registration state</a> that is one of firing or unregisteredWhileFiring.</p>
-  </spec-section>
-</spec-clause>
-
-<spec-clause id="privacy-considerations">
-  <h1>Privacy Considerations</h1>
-  <spec-section id="location-tracking">
-    <h1>Location Tracking</h1>
-    <p>Fetch requests within the onsync event while <a href="#dfn-in-the-background"> in the background</a> may reveal the client's IP address to the server after the user left the page. The <a href="#dfn-user-agent">user agent</a> should limit tracking by capping the number of retries and duration of sync events.</p>
-  </spec-section>
-
-  <spec-section id="history-leaking">
-    <h1>History Leaking</h1>
-    <p>Fetch requests within the onsync event while <a href="#dfn-in-the-background"> in the background</a> may reveal something about the client's navigation history to passive eavesdroppers. For instance, the client might visit site https://example.com, which registers a sync event, but doesn't fire until after the user has navigated away from the page and changed networks. Passive eavesdroppers on the new network may see the fetch requests that the onsync event makes. The fetch requests are HTTPS so the request contents will not be leaked but the domain may be (via DNS lookups and IP address of the request).</p>
-  </spec-section>
-</spec-clause>
-
-<spec-clause id="constructs">
-<h1>Constructs</h1>
-<p>A <a href="#sync-registration-interface">SyncRegistration</a> has an associated <a href="#dfn-registration-state">registration state</a>, <dfn id="dfn-state">state</dfn>.</p>
-<p>A <a href="#sync-registration-interface">SyncRegistration</a> has an associated unique identifier <dfn id="dfn-id">id</dfn>.</p>
-<p>A <a href="#sync-registration-interface">SyncRegistration</a> has an associated <a href="http://www.w3.org/TR/service-workers/#service-worker-registration-interface">ServiceWorkerRegistration</a>, <dfn id="dfn-swregistration">serviceWorkerRegistration</dfn>.</p>
-<p>A <a href="http://www.w3.org/TR/service-workers/#service-worker-registration-interface">ServiceWorkerRegistration</a> has an associated <dfn id="dfn-current-registration-list">currentRegistrationList</dfn> which is a List of <a href="#sync-registration-interface">SyncRegistrations</a>.</p>
-</spec-clause>
-
-<spec-clause id="service-worker-registration-extensions">
-  <h1>Extensions to the <a href="http://www.w3.org/TR/service-workers/#service-worker-registration-interface">ServiceWorkerRegistration</a> interface</h1>
-
-  <spec-idl>
-  [Exposed=(Window,ServiceWorker,Worker)]
-  partial interface <a href="http://www.w3.org/TR/service-workers/#service-worker-registration-interface">ServiceWorkerRegistration</a {
-    readonly attribute <a href="#sync-manager-interface">SyncManager</a> <a href="#registration-sync-attribute">sync</a>;
-  };
-  </spec-idl>
-
-
-  <spec-section id="registration-sync-attribute">
-    <h1>sync</h1>
-    The <dfn id="dfn-registration-sync-attribute">sync</dfn> attribute exposes a <a href="#sync-manager-interface">SyncManager</a>, which is where one-shot background sync registrations are managed.
-  </spec-section>
-</spec-clause>
-
-<spec-clause id="sync-manager-interface">
-  <h1>SyncManager interface</h1>
-  <p>The <a href="#sync-manager-interface">SyncManager interface</a> defines the operations to register and access sync registrations.</p>
-
-  <spec-idl>
-  [Exposed=(Window,ServiceWorker,Worker)]
-  interface SyncManager {
-    Promise&lt;SyncRegistration&gt; <a href="#sync-manager-register-method">register</a>(optional SyncRegistrationOptions options);
-    Promise&lt;SyncRegistration&gt; <a href="#sync-manager-get-registration-method">getRegistration</a>(DOMString tag);
-    Promise&lt;sequence&lt;SyncRegistration&gt;&gt; <a href="#sync-manager-get-registration-method">getRegistrations</a>();
-  };
-
-  dictionary SyncRegistrationOptions {
-    DOMString tag;
-  };
-  </spec-idl>
-
-
-  <spec-section id="sync-manager-register-method">
-    <h1>register(options)</h1>
-
-    <spec-algorithm>
-    <ol>
-      <li>Let <var>promise</var> be a new <a href="http://www.w3.org/TR/push-api/#dfn-promise">Promise</a>.</li>
-      <li>Return <var>promise</var> and continue the following steps asynchronously.</li>
-      <li>If in a document environment and the scheme of the URL is not https, reject promise with a <a href="http://www.w3.org/TR/push-api/#dfn-domexception">DOMException</a> whose name is "<a href="http://www.w3.org/TR/push-api/#dfn-securityerror">SecurityError</a>" and terminate these steps.</li>
-      <li>Let <var>serviceWorkerRegistration</var> be the <a href="#sync-manager-interface">SyncManager's</a> associated serviceWorkerRegistration.</li>
-      <li>If in a service worker or worker environment and <var>serviceWorkerRegistration</var> has no controlled client, reject promise with a <a href="http://www.w3.org/TR/push-api/#dfn-domexception">DOMException</a> whose name is "ErrorTypeNoPermission" and terminate these steps.</li>
-      <li>Let <var>currentRegistrationList</var> be <var>serviceWorkerRegistration</var>'s <a href="#dfn-current-registration-list">currentRegistrationList</a>.</li>
-      <li>Let <var>currentRegistration</var> be the registration in <var>currentRegistrationList</var> with <var>options</var>'s tag, else null.</li>
-      <li>If currentRegistration is not null and all of its options are the same as <var>options</var> then resolve <var>promise</var> with <var>currentRegistration</var> and terminate these steps.</li>
-      <li>If currentRegistration is not null (but its options differ):</li>
-        <ol>
-          <li>If currentRegistration's state is a <a href="#def-firing-registration-state">firing registration state</a> set its state to unregisteredWhileFiring, else set its state to unregistered.</li>
-          <li>Remove <var>currentRegistration</var> from <var>currentRegistrationList</var>.</li>
+dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-syncregistrationoptions">SyncRegistrationOptions<a class="self-link" href="#dictdef-syncregistrationoptions"></a></dfn> {
+  DOMString <dfn class="idl-code" data-dfn-for="SyncRegistrationOptions" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-syncregistrationoptions-tag">tag<a class="self-link" href="#dom-syncregistrationoptions-tag"></a></dfn>;
+};
+</pre>
+     <p>The <code><dfn class="idl-code" data-dfn-for="SyncManager" data-dfn-type="method" data-export="" data-lt="register(options)|register()" id="dom-syncmanager-register" title="register(options)">register(<var>options</var>)<a class="self-link" href="#dom-syncmanager-register"></a></dfn></code> method, when invoked, MUST return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+     <ol>
+      <li> Let <var>serviceWorkerRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#syncmanager">SyncManager</a></code>'s associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a>. 
+      <li> If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> instance, and the <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-active-worker">active worker</a> is not currently <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-control">controlling</a> any <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client">clients</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code> and abort these steps. 
+      <li> Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#sync-registration">registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registrations</a> whose <a data-link-type="dfn" href="#tag">tag</a> equals <var>options.tag</var> if it exists, else null. 
+      <li> If <var>currentRegistration</var> is not null, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve</a> <var>promise</var> with a new {{SyncRegistration>> instance associated with <var>currentRegistration</var> and abort these steps. 
+      <li> Let <var>newRegistration</var> be a new <a data-link-type="dfn" href="#sync-registration">sync registration</a>. 
+      <li> Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="#tag">tag</a> to <var>options.tag</var>. 
+      <li> Set <var>newRegistration</var>’s associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a> to <var>serviceWorkerRegistration</var>. 
+      <li> Add <var>newRegistration</var> to <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registrations</a>. 
+      <li> <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">Resolve</a> <var>promise</var> with a new <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code> instance associated with <var>newRegistration</var>. 
+     </ol>
+     <p>The <code><dfn class="idl-code" data-dfn-for="SyncManager" data-dfn-type="method" data-export="" id="dom-syncmanager-getregistration" title="getRegistration(tag)">getRegistration(<var>tag</var>)<a class="self-link" href="#dom-syncmanager-getregistration"></a></dfn></code> method when invoked, MUST return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+     <ol>
+      <li> Let <var>serviceWorkerRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#syncmanager">SyncManager</a></code>'s associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a>. 
+      <li> Let <var>currentRegistration</var> be the <a data-link-type="dfn" href="#sync-registration">registration</a> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registrations</a> whose <a data-link-type="dfn" href="#tag">tag</a> equals <var>options.tag</var> if it exists, else null. 
+      <li> If <var>currentRegistration</var> is null, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve</a> <var>promise</var> with null. 
+      <li> <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">Resolve</a> <var>promise</var> with a new <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code> instance associated with <var>currentRegistration</var>. 
+     </ol>
+     <p>The <code><dfn class="idl-code" data-dfn-for="SyncManager" data-dfn-type="method" data-export="" id="dom-syncmanager-getregistrations" title="getRegistrations()">getRegistrations()<a class="self-link" href="#dom-syncmanager-getregistrations"></a></dfn></code> method when invoked, MUST return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+     <ol>
+      <li> Let <var>serviceWorkerRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#syncmanager">SyncManager</a></code>'s associated <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a>. 
+      <li>Let <var>currentRegistrations</var> be a new <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-sequence">sequence</a></code>.
+      <li> For each <var>registration</var> in <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registrations</a>, add a new <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code> instance associated with <var>registration</var> to <var>currentRegistrations</var>. 
+      <li> <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">Resolve</a> <var>promise</var> with <var>currentRegistrations</var>. 
+     </ol>
+     <p class="issue" id="issue-06bf2d52"><a class="self-link" href="#issue-06bf2d52"></a> Should register/getRegistration/getRegistrations return a new SyncRegistration instance each time, or should it attempt to return the same instance if called from a context where it had already returned a particular registration?</p>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="5.3" id="sync-registration-interface"><span class="secno">5.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code> interface</span><a class="self-link" href="#sync-registration-interface"></a></h3>
+<pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="syncregistration">SyncRegistration<a class="self-link" href="#syncregistration"></a></dfn> {
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dom-syncregistration-tag">tag</a>;
+  readonly attribute Promise&lt;boolean> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="Promise<boolean> " href="#dom-syncregistration-done">done</a>;
+  Promise&lt;boolean> <a class="idl-code" data-link-type="method" href="#dom-syncregistration-unregister">unregister</a>();
+};
+</pre>
+     <div class="note no-marker" role="note">
+      <div class="marker">NOTE: SyncRegistration members</div>
+       The <code class="idl"><a data-link-type="idl" href="#dom-syncregistration-tag">tag</a></code> attribute exposes the tag provided in options during registration. 
+      <p>The <code class="idl"><a data-link-type="idl" href="#dom-syncregistration-done">done</a></code> attribute returns a promise which will resolve as soon as the service worker has finished handling a sync event. It resolves to true if the event was handled succesfully, and resolves to false if something went wrong.</p>
+      <p>The <code class="idl"><a data-link-type="idl" href="#dom-syncregistration-unregister">unregister()</a></code> method can be called to unregister the sync registration.</p>
+     </div>
+     <p>A <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code> instance has an associated <a data-link-type="dfn" href="#sync-registration">sync registration</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code> instance has an associated <dfn data-dfn-type="dfn" data-noexport="" id="done-promise">done promise<a class="self-link" href="#done-promise"></a></dfn>, a promise. It is initially set to null.</p>
+     <p>The <code><dfn class="idl-code" data-dfn-for="SyncRegistration" data-dfn-type="attribute" data-export="" id="dom-syncregistration-tag" title="tag">tag<a class="self-link" href="#dom-syncregistration-tag"></a></dfn></code> attribute MUST return the <a data-link-type="dfn" href="#tag">tag</a> of the associated <a data-link-type="dfn" href="#sync-registration">sync registration</a>.</p>
+     <p>The <code><dfn class="idl-code" data-dfn-for="SyncRegistration" data-dfn-type="attribute" data-export="" id="dom-syncregistration-done" title="done">done<a class="self-link" href="#dom-syncregistration-done"></a></dfn></code> attribute MUST return the result of running the following steps:</p>
+     <ol>
+      <li>
+        If the <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code>'s <a data-link-type="dfn" href="#done-promise">done promise</a> is null, then: 
+       <ol>
+        <li> Let <var>promise</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">a new promise</a>. 
+        <li> Set the <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code>'s <a data-link-type="dfn" href="#done-promise">done promise</a> to <var>promise</var>. 
+        <li>
+          <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">In parallel</a>, when/if the <a data-link-type="dfn" href="#sync-registration">sync registration</a>’s <a data-link-type="dfn" href="#registration-state">registration state</a> becomes a <a data-link-type="dfn" href="#final-registration-state">final registration state</a>, run the following steps: 
+         <ol>
+          <li> If the <a data-link-type="dfn" href="#sync-registration">sync registrations</a>’s <a data-link-type="dfn" href="#registration-state">registration state</a> is <a data-link-type="dfn" href="#success">success</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve</a> <var>promise</var> with true, else <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve</a> <var>promise</var> with false. 
+         </ol>
        </ol>
-      <li>Let newRegistration be a new SyncRegistration.</li>
-      <li>Replace the options in <var>newRegistration</var> with the input <var>options</var>.
-      <li>Set <var>newRegistration</var>'s associated id to a new unique id.</li>
-      <li>Set <var>newRegistration</var>'s associated state to pending.</li>
-      <li>Set <var>newRegistration</var>'s associated serviceWorkerRegistration to <var>serviceWorkerRegistration</var>.
-      <li>Add <var>newRegistration</var> to <var>currentRegistrations</var>.
-      <li>Resolve <var>promise</var> with <var>newRegistration</var> and terminate these steps.</li>
-    </ol>
-    </spec-algorithm>
-  </spec-section>
+      <li> Return <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code>'s <a data-link-type="dfn" href="#done-promise">done promise</a>. 
+     </ol>
+     <p>The <code><dfn class="idl-code" data-dfn-for="SyncRegistration" data-dfn-type="method" data-export="" id="dom-syncregistration-unregister" title="unregister()">unregister()<a class="self-link" href="#dom-syncregistration-unregister"></a></dfn></code> method when invoked, MUST return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+     <ol>
+      <li> If this <a data-link-type="dfn" href="#sync-registration">sync registration</a> is not currently in the <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registrations</a> associated with this <a data-link-type="dfn" href="#sync-registration">sync registration</a>’s <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve</a> <var>promise</var> with false and abort these steps. 
+      <li> If the <a data-link-type="dfn" href="#sync-registration">sync registration</a>’s <a data-link-type="dfn" href="#registration-state">registration state</a> is a <a data-link-type="dfn" href="#firing-registration-state">firing registration state</a>, set its <a data-link-type="dfn" href="#registration-state">state</a> to <a data-link-type="dfn" href="#unregisteredwhilefiring">unregisteredWhileFiring</a>, else set its <a data-link-type="dfn" href="#registration-state">state</a> to <a data-link-type="dfn" href="#unregistered">unregistered</a>. 
+      <li> Remove this <a data-link-type="dfn" href="#sync-registration">sync registration</a> from the <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registrations</a> associated with this <a data-link-type="dfn" href="#sync-registration">sync registration</a>’s <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a>. 
+      <li> <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">Resolve</a> <var>promise</var> with true. 
+     </ol>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="5.4" id="sync-event"><span class="secno">5.4. </span><span class="content">The <dfn data-dfn-type="dfn" data-noexport="" id="sync">sync<a class="self-link" href="#sync"></a></dfn> event</span><a class="self-link" href="#sync-event"></a></h3>
+<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a> {
+  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-type="EventHandler " id="dom-serviceworkerglobalscope-onsync">onsync<a class="self-link" href="#dom-serviceworkerglobalscope-onsync"></a></dfn>;
+};
 
+[<dfn class="idl-code" data-dfn-for="SyncEvent" data-dfn-type="constructor" data-export="" data-lt="SyncEvent(type, init)" id="dom-syncevent-syncevent">Constructor<a class="self-link" href="#dom-syncevent-syncevent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="SyncEvent/SyncEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-syncevent-syncevent-type-init-type">type<a class="self-link" href="#dom-syncevent-syncevent-type-init-type"></a></dfn>, <a data-link-type="idl-name" href="#dictdef-synceventinit">SyncEventInit</a> <dfn class="idl-code" data-dfn-for="SyncEvent/SyncEvent(type, init)" data-dfn-type="argument" data-export="" id="dom-syncevent-syncevent-type-init-init">init<a class="self-link" href="#dom-syncevent-syncevent-type-init-init"></a></dfn>), Exposed=ServiceWorker]
+interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="syncevent">SyncEvent<a class="self-link" href="#syncevent"></a></dfn> : <a data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface">ExtendableEvent</a> {
+  readonly attribute <a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a> <dfn class="idl-code" data-dfn-for="SyncEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="SyncRegistration " id="dom-syncevent-registration">registration<a class="self-link" href="#dom-syncevent-registration"></a></dfn>;
+};
 
-  <spec-section id="sync-manager-get-registration-method">
-    <h1>getRegistration(tag)</h1>
+dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-synceventinit">SyncEventInit<a class="self-link" href="#dictdef-synceventinit"></a></dfn> : <a data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary">ExtendableEventInit</a> {
+  required <a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a> <dfn class="idl-code" data-dfn-for="SyncEventInit" data-dfn-type="dict-member" data-export="" data-type="SyncRegistration " id="dom-synceventinit-registration">registration<a class="self-link" href="#dom-synceventinit-registration"></a></dfn>;
+};
+</pre>
+     <p class="note" role="note">Note: The <code class="idl"><a data-link-type="idl" href="#syncevent">SyncEvent</a></code> interface represents a firing sync registration. If the page (or worker) that registered the event is running, the user agent should fire the sync event as soon as network connectivity is available. Otherwise, the user agent should run at the soonest convenience. If the user agent decides to retry a failed event, it may retry at a time of its choosing.</p>
+     <p class="issue" id="issue-2b057c9c"><a class="self-link" href="#issue-2b057c9c"></a> More formally spec when a sync event should be fired.</p>
+     <p>To <dfn data-dfn-type="dfn" data-noexport="" id="fire-a-sync-event">fire a sync event<a class="self-link" href="#fire-a-sync-event"></a></dfn> for a <a data-link-type="dfn" href="#sync-registration">sync registration</a> <var>registration</var>, the user agent MUST run the following steps:</p>
+     <ol>
+      <li> <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> is <a data-link-type="dfn" href="#pending">pending</a>. 
+      <li> Let <var>serviceWorkerRegistration</var> be the <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a> associated with <var>registration</var>. 
+      <li> <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">Assert</a>: <var>registration</var> exists in the <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registrations</a> associated with <var>serviceWorkerRegistration</var>. 
+      <li> Set <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> to <a data-link-type="dfn" href="#firing">firing</a>. 
+      <li>
+        Invoke the <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#handle-functional-event-algorithm">Handle Functional Event</a> algorithm with <var>registration</var> and the following substeps as arguments. 
+       <ol>
+        <li> Let <var>globalObject</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> these steps are called with. 
+        <li> Create a <a data-link-type="dfn" href="https://html.spec.whatwg.org/#concept-events-trusted">trusted</a> event <var>e</var> that uses the <code class="idl"><a data-link-type="idl" href="#syncevent">SyncEvent</a></code> interface, with the event type <a data-link-type="dfn" href="#sync">sync</a>, which does not bubble and has no default action. 
+        <li> Let the <code class="idl"><a data-link-type="idl" href="#dom-syncevent-registration">registration</a></code> attribute of <var>e</var> be initialized to a new <code class="idl"><a data-link-type="idl" href="#syncregistration">SyncRegistration</a></code> associated with <var>registration</var>. 
+        <li> Dispatch <var>e</var> at <var>globalObject</var>. 
+        <li> Let <var>waitUntilPromise</var> be the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-extend-lifetime-promises">extended lifetime promises</a>. 
+        <li>
+          <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">Upon fulfillment</a> of <var>waitUntilPromise</var>, perform the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+         <ol>
+          <li> Remove <var>registration</var> from <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registration</a>, if <var>registration</var> is still in that list. 
+          <li> Set <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> to <a data-link-type="dfn" href="#success">success</a>. 
+         </ol>
+        <li>
+          <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">Upon fulfillment</a> of <var>waitUntilPromise</var>, or if the script has been aborted by the <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm">termination</a> of the <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept">service worker</a>, perform the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+         <ol>
+          <li>
+            If <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> is <a data-link-type="dfn" href="#unregisteredwhilefiring">unregisteredWhileFiring</a>: 
+           <ol>
+            <li> If <var>e</var> <a data-link-type="dfn" href="#should-be-retried">should be retried</a>, set <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> to <a data-link-type="dfn" href="#unregistered">unregistered</a>. 
+            <li> Else set <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> to <a data-link-type="dfn" href="#failed">failed</a>. 
+           </ol>
+          <li>
+            Else: 
+           <ol>
+            <li> If <var>e</var> <a data-link-type="dfn" href="#should-be-retried">should be retried</a>, set <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> to <a data-link-type="dfn" href="#pending">pending</a>. 
+            <li>
+              Else: 
+             <ol>
+              <li> Remove <var>registration</var> from <var>serviceWorkerRegistration</var>’s <a data-link-type="dfn" href="#list-of-sync-registrations">list of sync registration</a>. 
+              <li> Set <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> to <a data-link-type="dfn" href="#failed">failed</a>. 
+             </ol>
+           </ol>
+         </ol>
+       </ol>
+     </ol>
+     <p>A <a href="#sync-event">sync event</a> <dfn data-dfn-type="dfn" data-noexport="" id="should-be-retried">should be retried<a class="self-link" href="#should-be-retried"></a></dfn> based on some user agent defined heuristics.</p>
+     <p class="issue" id="issue-8272893c"><a class="self-link" href="#issue-8272893c"></a> retry behavior should probably be specced a bit better.</p>
+    </section>
+   </section>
+  </main>
+  <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
+  <p> Conformance requirements are expressed with a combination of descriptive assertions and RFC 2119 terminology.
+        The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+        in the normative parts of this document
+        are to be interpreted as described in RFC 2119.
+        However, for readability,
+        these words do not appear in all uppercase letters in this specification. </p>
+  <p> All of the text of this specification is normative
+        except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+  <p> Examples in this specification are introduced with the words “for example”
+        or are set apart from the normative text with <code>class="example"</code>, like this: </p>
+  <div class="example" id="example-ae2b6bc0"><a class="self-link" href="#example-ae2b6bc0"></a> This is an example of an informative example. </div>
+  <p> Informative notes begin with the word “Note”
+        and are set apart from the normative text with <code>class="note"</code>, like this: </p>
+  <p class="note" role="note"> Note, this is an informative note. </p>
+  <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="indexlist">
+   <li><a href="#dom-syncregistration-done">done</a><span>, in §5.3</span>
+   <li><a href="#done-promise">done promise</a><span>, in §5.3</span>
+   <li><a href="#failed">failed</a><span>, in §3</span>
+   <li><a href="#final-registration-state">final registration state</a><span>, in §3</span>
+   <li><a href="#fire-a-sync-event">fire a sync event</a><span>, in §5.4</span>
+   <li><a href="#firing">firing</a><span>, in §3</span>
+   <li><a href="#firing-registration-state">firing registration state</a><span>, in §3</span>
+   <li><a href="#dom-syncmanager-getregistrations">getRegistrations()</a><span>, in §5.2</span>
+   <li><a href="#dom-syncmanager-getregistration">getRegistration(tag)</a><span>, in §5.2</span>
+   <li><a href="#dom-syncevent-syncevent-type-init-init">init</a><span>, in §5.4</span>
+   <li><a href="#in-the-background">in the background</a><span>, in §2</span>
+   <li><a href="#list-of-sync-registrations">list of sync registrations</a><span>, in §3</span>
+   <li><a href="#dom-serviceworkerglobalscope-onsync">onsync</a><span>, in §5.4</span>
+   <li><a href="#dom-syncmanager-register-options-options">options</a><span>, in §5.2</span>
+   <li><a href="#pending">pending</a><span>, in §3</span>
+   <li><a href="#dom-syncmanager-register">register()</a><span>, in §5.2</span>
+   <li><a href="#dom-syncmanager-register">register(options)</a><span>, in §5.2</span>
+   <li>
+    registration
+    <ul>
+     <li><a href="#dom-syncevent-registration">attribute for SyncEvent</a><span>, in §5.4</span>
+     <li><a href="#dom-synceventinit-registration">dict-member for SyncEventInit</a><span>, in §5.4</span>
+    </ul>
+   <li><a href="#registration-state">registration state</a><span>, in §3</span>
+   <li><a href="#should-be-retried">should be retried</a><span>, in §5.4</span>
+   <li><a href="#success">success</a><span>, in §3</span>
+   <li>
+    sync
+    <ul>
+     <li><a href="#dom-serviceworkerregistration-sync">attribute for ServiceWorkerRegistration</a><span>, in §5.1</span>
+     <li><a href="#dom-syncmanager-sync">attribute for SyncManager</a><span>, in §5.1</span>
+     <li><a href="#sync">definition of</a><span>, in §5.4</span>
+    </ul>
+   <li><a href="#syncevent">SyncEvent</a><span>, in §5.4</span>
+   <li><a href="#dictdef-synceventinit">SyncEventInit</a><span>, in §5.4</span>
+   <li><a href="#dom-syncevent-syncevent">SyncEvent(type, init)</a><span>, in §5.4</span>
+   <li><a href="#syncmanager">SyncManager</a><span>, in §5.2</span>
+   <li><a href="#syncregistration">SyncRegistration</a><span>, in §5.3</span>
+   <li><a href="#sync-registration">sync registration</a><span>, in §3</span>
+   <li><a href="#dictdef-syncregistrationoptions">SyncRegistrationOptions</a><span>, in §5.2</span>
+   <li>
+    tag
+    <ul>
+     <li><a href="#tag">definition of</a><span>, in §3</span>
+     <li><a href="#dom-syncmanager-getregistration-tag-tag">argument for SyncManager/getRegistration(tag)</a><span>, in §5.2</span>
+     <li><a href="#dom-syncregistrationoptions-tag">dict-member for SyncRegistrationOptions</a><span>, in §5.2</span>
+     <li><a href="#dom-syncregistration-tag">attribute for SyncRegistration</a><span>, in §5.3</span>
+    </ul>
+   <li><a href="#dom-syncevent-syncevent-type-init-type">type</a><span>, in §5.4</span>
+   <li><a href="#dom-syncregistration-unregister">unregister()</a><span>, in §5.3</span>
+   <li><a href="#unregistered">unregistered</a><span>, in §3</span>
+   <li><a href="#unregisteredwhilefiring">unregisteredWhileFiring</a><span>, in §3</span>
+  </ul>
+  <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="indexlist">
+   <li>
+    <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-sequence">sequence</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-ecma-262">[ECMA-262]</a> defines the following terms:
+    <ul>
+     <li><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">assert</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
+    <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>
+     <li><a href="https://html.spec.whatwg.org/#concept-events-trusted">trusted</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-powerful-features">[powerful-features]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">secure context</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-promises-guide">[promises-guide]</a> defines the following terms:
+    <ul>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">a new promise</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">upon fulfillment</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">waiting for all</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-service-workers">[service-workers]</a> defines the following terms:
+    <ul>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface">ExtendableEvent</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary">ExtendableEventInit</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface">ServiceWorkerRegistration</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-active-worker">active worker</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client">client</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-control">control</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-extend-lifetime-promises">extended lifetime promises</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#handle-functional-event-algorithm">handle functional event</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept">service worker</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">service worker registration</a>
+     <li><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm">termination</a>
+    </ul>
+  </ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-ecma-262"><a class="self-link" href="#biblio-ecma-262"></a>[ECMA-262]
+   <dd>Allen Wirfs-Brock. <a href="http://www.ecma-international.org/ecma-262/6.0/">ECMA-262 6th Edition, The ECMAScript 2015 Language Specification</a>. June 2015. Standard. URL: <a href="http://www.ecma-international.org/ecma-262/6.0/">http://www.ecma-international.org/ecma-262/6.0/</a>
+   <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
+   <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-webidl"><a class="self-link" href="#biblio-webidl"></a>[WebIDL]
+   <dd>Cameron McCormack; Boris Zbarsky. <a href="http://www.w3.org/TR/WebIDL-1/">WebIDL Level 1</a>. 4 August 2015. WD. URL: <a href="http://www.w3.org/TR/WebIDL-1/">http://www.w3.org/TR/WebIDL-1/</a>
+   <dt id="biblio-powerful-features"><a class="self-link" href="#biblio-powerful-features"></a>[POWERFUL-FEATURES]
+   <dd>Mike West; Yan Zhu. <a href="http://www.w3.org/TR/powerful-features/">Privileged Contexts</a>. 24 April 2015. WD. URL: <a href="http://www.w3.org/TR/powerful-features/">http://www.w3.org/TR/powerful-features/</a>
+   <dt id="biblio-promises-guide"><a class="self-link" href="#biblio-promises-guide"></a>[PROMISES-GUIDE]
+   <dd><a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>. 24 July 2015. Finding of the W3C TAG. URL: <a href="https://www.w3.org/2001/tag/doc/promises-guide">https://www.w3.org/2001/tag/doc/promises-guide</a>
+   <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-service-workers"><a class="self-link" href="#biblio-service-workers"></a>[SERVICE-WORKERS]
+   <dd>Alex Russell; Jungkee Song; Jake Archibald. <a href="http://www.w3.org/TR/service-workers/">Service Workers</a>. 25 June 2015. WD. URL: <a href="http://www.w3.org/TR/service-workers/">http://www.w3.org/TR/service-workers/</a>
+  </dl>
+  <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface">ServiceWorkerRegistration</a> {
+  readonly attribute <a data-link-type="idl-name" href="#syncmanager">SyncManager</a> <a data-readonly="" data-type="SyncManager " href="#dom-serviceworkerregistration-sync">sync</a>;
+};
 
-    <spec-algorithm>
-    <ol>
-      <li>Let <var>promise</var> be a new <a href="http://www.w3.org/TR/push-api/#dfn-promise">Promise</a>.</li>
-      <li>Return <var>promise</var> and continue the following steps asynchronously.</li>
-      <li>If in a document environment and the scheme of the URL is not https, reject promise with a <a href="http://www.w3.org/TR/push-api/#dfn-domexception">DOMException</a> whose name is "<a href="http://www.w3.org/TR/push-api/#dfn-securityerror">SecurityError</a>" and terminate these steps.</li>
-      <li>Let <var>serviceWorkerRegistration</var> be the <a href="#sync-manager-interface">SyncManager's</a> associated service worker registration.</li>
-      <li>Let <var>currentRegistrationList</var> be <var>serviceWorkerRegistration</var>'s <a href="#dfn-active-regisration-list">currentRegistrationList</a>.</li>
-      <li>Let <var>currentRegistration</var> be the registration in <var>currentRegistrationList</var> with the same tag as found in <var>options</var> if it exists, else null.</li>
-      <li>Resolve promise with <var>currentRegistration</var>.</li>
-    </ol>
-    </spec-algorithm>
-  </spec-section>
+[Exposed=(Window,Worker)]
+interface <a href="#syncmanager">SyncManager</a> {
+  Promise&lt;<a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-register">register</a>(optional <a data-link-type="idl-name" href="#dictdef-syncregistrationoptions">SyncRegistrationOptions</a> <a href="#dom-syncmanager-register-options-options">options</a>);
+  Promise&lt;<a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-getregistration">getRegistration</a>(DOMString <a href="#dom-syncmanager-getregistration-tag-tag">tag</a>);
+  Promise&lt;sequence&lt;<a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a>>> <a class="idl-code" data-link-type="method" href="#dom-syncmanager-getregistrations">getRegistrations</a>();
+};
 
-  <spec-section id="sync-manager-get-registrations-method">
-    <h1>getRegistrations()</h1>
+dictionary <a href="#dictdef-syncregistrationoptions">SyncRegistrationOptions</a> {
+  DOMString <a data-type="DOMString " href="#dom-syncregistrationoptions-tag">tag</a>;
+};
 
-    <spec-algorithm>
-    <ol>
-      <li>Let <var>promise</var> be a new <a href="http://www.w3.org/TR/push-api/#dfn-promise">Promise</a>.</li>
-      <li>Return <var>promise</var> and continue the following steps asynchronously.</li>
-      <li>If in a document environment and the scheme of the URL is not https, reject promise with a <a href="http://www.w3.org/TR/push-api/#dfn-domexception">DOMException</a> whose name is "<a href="http://www.w3.org/TR/push-api/#dfn-securityerror">SecurityError</a>" and terminate these steps.</li>
-      <li>Let <var>serviceWorkerRegistration</var> be the <a href="#sync-manager-interface">SyncManager's</a> associated service worker registration.</li>
-      <li>Let <var>currentRegistrationList</var> be <var>serviceWorkerRegistration</var>'s <a href="#dfn-active-regisration-list">currentRegistrationList</a>.</li>
-      <li>Resolve promise with currentRegistrationList.</li>
-    </ol>
-    </spec-algorithm>
-  </spec-section>
-</spec-clause>
+[Exposed=(Window,Worker)]
+interface <a href="#syncregistration">SyncRegistration</a> {
+  readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dom-syncregistration-tag">tag</a>;
+  readonly attribute Promise&lt;boolean> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="Promise<boolean> " href="#dom-syncregistration-done">done</a>;
+  Promise&lt;boolean> <a class="idl-code" data-link-type="method" href="#dom-syncregistration-unregister">unregister</a>();
+};
 
-<spec-clause id="sync-registration-interface">
-  <h1>SyncRegistration interface</h1>
-  <p>The <a href="#sync-registration-interface">SyncRegistration interface</a> defines the operations to unregister and inquire about the status of a sync registration.</p>
+partial interface <a class="idl-code" data-link-type="interface" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a> {
+  attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a data-type="EventHandler " href="#dom-serviceworkerglobalscope-onsync">onsync</a>;
+};
 
-  <spec-idl>
-  [Exposed=(Window,ServiceWorker,Worker)]
-  interface SyncRegistration {
-    readonly attribute DOMString tag;
-    readonly attribute Promise&lt;boolean&gt; done;
-    Promise&lt;boolean&gt; unregister();
-  };
-  </spec-idl>
+[<a href="#dom-syncevent-syncevent">Constructor</a>(DOMString <a href="#dom-syncevent-syncevent-type-init-type">type</a>, <a data-link-type="idl-name" href="#dictdef-synceventinit">SyncEventInit</a> <a href="#dom-syncevent-syncevent-type-init-init">init</a>), Exposed=ServiceWorker]
+interface <a href="#syncevent">SyncEvent</a> : <a data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface">ExtendableEvent</a> {
+  readonly attribute <a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a> <a data-readonly="" data-type="SyncRegistration " href="#dom-syncevent-registration">registration</a>;
+};
 
-  <spec-section id="sync-registration-tag-attribute">
-    <h1>tag</h1>
-    The <dfn id="dfn-sync-registration-tag-attribute">tag</dfn> attribute exposes the tag provided in options during registration.
-  </spec-section>
+dictionary <a href="#dictdef-synceventinit">SyncEventInit</a> : <a data-link-type="idl-name" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary">ExtendableEventInit</a> {
+  required <a data-link-type="idl-name" href="#syncregistration">SyncRegistration</a> <a data-type="SyncRegistration " href="#dom-synceventinit-registration">registration</a>;
+};
 
-  <spec-section id="sync-registration-done-attribute">
-    <h1>done</h1>
-
-    <spec-algorithm>
-    <ol>
-      <li>Let <var>syncRegistration</var> be the registration associated with this method's SyncRegistration.</li>
-      <li>Let <var>promise</var> be a new <a href="http://www.w3.org/TR/push-api/#dfn-promise">Promise</a>.</li>
-      <li>Return <var>promise</var> and continue the following steps asynchronously.</li>
-      <li>If in a document environment and the scheme of the URL is not https, reject promise with a <a href="http://www.w3.org/TR/push-api/#dfn-domexception">DOMException</a> whose name is "<a href="http://www.w3.org/TR/push-api/#dfn-securityerror">SecurityError</a>" and terminate these steps.</li>
-      <li>If <var>syncRegistration</var>'s state is a <a href="#final-registration-state">final registration state</a>, resolve promise with true if <var>syncRegistration</var>'s state is success, otherwise false. Terminate these steps.</li>
-      <li>Once <var>syncRegistration</var>'s state changes to a <a href="#final-registration-state">final registration state</a>, resolve promise with true if the state is success otherwise false.
-    </ol>
-    </spec-algorithm>
-
-
-  </spec-section>
-
-    <spec-section id="sync-registration-unregister-method">
-    <h1>unregister()</h1>
-
-    <spec-algorithm>
-    <ol>
-      <li>Let <var>syncRegistration</var> be the registration associated with this method's SyncRegistration.</li>
-      <li>Let <var>promise</var> be a new <a href="http://www.w3.org/TR/push-api/#dfn-promise">Promise</a>.</li>
-      <li>Return <var>promise</var> and continue the following steps asynchronously.</li>
-      <li>If in a document environment and the scheme of the URL is not https, reject promise with a <a href="http://www.w3.org/TR/push-api/#dfn-domexception">DOMException</a> whose name is "<a href="http://www.w3.org/TR/push-api/#dfn-securityerror">SecurityError</a>" and terminate these steps.</li>
-      <li>Let <var>serviceWorkerRegistration</var> be the <a href="#sync-registration-interface">SyncRegistration's</a> associated service worker registration.</li>
-      <li>Let <var>currentRegistrationList</var> be <var>serviceWorkerRegistration</var>'s <a href="#dfn-active-regisration-list">currentRegistrationList</a>.</li>
-      <li>Let <var>currentRegistration</var> be the registration in <var>currentRegistrationList</var> with the same id as associated with <var>syncRegistration</var>, else null.</li>
-      <li>If <var>currentRegistration</var> is null then resolve promise with false and terminate these steps.</li>
-      <li>If currentRegistration's state is <a href="#dfn-firing-registration-state">firing registration state</a> set its state to unregisteredWhileFiring, else set its state to the <a href="#final-registration-state">final registration state</a> unregistered.</li>
-      <li>Remove <var>currentRegistration</var> from <var>currentRegistrationList</var>.</li>
-      <li>Resolve promise with true.</li>
-    </ol>
-    </spec-algorithm>
-  </spec-section>
-
-
-</spec-clause>
-
-<spec-clause id="service-worker-sync-event">
-  <h1>SyncEvent</h1>
-
-  <p>The SyncEvent interface represents a firing sync registration. If the page (or worker) that registered the event is running, the user agent should fire the sync event as soon as network connectivity is available. Otherwise, the user agent should run at the soonest convenience. If the user agent decides to retry a failed event, it may retry at a time of its choosing.</p>
-
-  <spec-idl>
-  [Constructor(DOMString type, SyncEventInit init), Exposed=ServiceWorker]
-  interface SyncEvent : ExtendableEvent {
-    readonly attribute SyncRegistration registration;
-  };
-
-  dictionary SyncEventInit : ExtendableEventInit {
-    required SyncRegistration registration;
-  };
-  </spec-idl>
-
-  <p>To fire a background sync registration for SyncRegistration <var>syncRegistration</var> in the pending state, the user agent must run the following steps:</p>
-  <spec-algorithm>
-  <ol>
-    <li>Set syncRegistration's state to firing.</li>
-    <li>If the Service Worker associated with the webapp is not running, start it.</li>
-    <li>Let <var>currentRegistrationList</var> be the Service Worker associated with the webapp's <a href="#dfn-active-regisration-list">currentRegistrationList</a>.</li>
-    <li>Let <var>scope</var> be the ServiceWorkerGlobalScope of the Service Worker associated with the webapp.</li>
-    <li>Let <var>event</var> be a new SyncEvent, whose registration attribute is <var>syncRegistration</var>.</li>
-    <li>Queue a task to fire <var>event</var> as a simple event nmed sync at scope.</li>
-    <li>If the event runs without calling waitUntil or the waitUntil resolves:</li>
-      <ol>
-        <li>Remove any SyncRegistration from <var>currentRegistrationList</var> with syncRegistration's associated id.</li>
-        <li>Set syncRegistration's state to <a href="#final-registration-state">final registration state</a> success.</li>
-      </ol>
-    <li>Else (the waitUntil rejects):</li>
-      <ol>
-        <li>If syncRegistration's state is unregisteredWhileFiring:</li>
-          <ol>
-            <li>If the user agent would have retried the registration if its state were firing set syncRegistration's state to <a href="#final-registration-state">final registration state</a> unregistered else failed</li>
-          </ol>
-        <li>Else (the state is firing):</li>
-          <ol>
-            <li>If the user agent will retry:</li>
-              <ol>
-                <li>Set syncRegistration's state to pending.</li>
-              </ol>
-          <li>Else:</li>
-              <ol>
-                <li>Remove any SyncRegistration from <var>currentRegistrationList</var> with syncRegistration's associated id.</li>
-                <li>Set syncRegistration's state to <a href="#final-registration-state">final registration state</a> failed.</li>
-              </ol>
-          </ol>
-      </ol>
-  </ol>
-  </spec-algorithm>
-
-  <spec-section id="sync-event-registration-attribute">
-    <h1>event.registration</h1>
-    <p>registration attribute must return the value it was initialized to.</p>
-  </spec-section>
-</spec-clause>
-
-<spec-clause id="acknowledgements">
-  <h1>Acknowledgements</h2>
-
-  <p>Thanks go to ....</p>
-
-  <p>The authors would also like to thank Jeffrey Yasskin for his scripts and formatting tools which have been essential in the production of this specification.</p>
-</spec-clause>
-</body>
+</pre>
+  <h2 class="no-num heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue"> Nothing is limiting fetch requests to be HTTPS only.<a href="#issue-9a916108"> ↵ </a></div>
+   <div class="issue"> Should register/getRegistration/getRegistrations return a new SyncRegistration instance each time, or should it attempt to return the same instance if called from a context where it had already returned a particular registration?<a href="#issue-06bf2d52"> ↵ </a></div>
+   <div class="issue"> More formally spec when a sync event should be fired.<a href="#issue-2b057c9c"> ↵ </a></div>
+   <div class="issue"> retry behavior should probably be specced a bit better.<a href="#issue-8272893c"> ↵ </a></div>
+  </div>
+ </body>
 </html>

--- a/spec/index.html
+++ b/spec/index.html
@@ -148,7 +148,6 @@
     <section>
      <h3 class="heading settled" data-level="4.2" id="history-leaking"><span class="secno">4.2. </span><span class="content">History Leaking</span><a class="self-link" href="#history-leaking"></a></h3>
       Fetch requests within the onsync event while <a data-link-type="dfn" href="#in-the-background">in the background</a> may reveal something about the client’s navigation history to passive eavesdroppers. For instance, the client might visit site https://example.com, which registers a sync event, but doesn’t fire until after the user has navigated away from the page and changed networks. Passive eavesdroppers on the new network may see the fetch requests that the onsync event makes. The fetch requests are HTTPS so the request contents will not be leaked but the domain may be (via DNS lookups and IP address of the request). 
-     <p class="issue" id="issue-9a916108"><a class="self-link" href="#issue-9a916108"></a> Nothing is limiting fetch requests to be HTTPS only.</p>
     </section>
    </section>
    <section>
@@ -491,7 +490,6 @@ dictionary <a href="#dictdef-synceventinit">SyncEventInit</a> : <a data-link-typ
 </pre>
   <h2 class="no-num heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> Nothing is limiting fetch requests to be HTTPS only.<a href="#issue-9a916108"> ↵ </a></div>
    <div class="issue"> Should register/getRegistration/getRegistrations return a new SyncRegistration instance each time, or should it attempt to return the same instance if called from a context where it had already returned a particular registration?<a href="#issue-06bf2d52"> ↵ </a></div>
    <div class="issue"> More formally spec when a sync event should be fired.<a href="#issue-2b057c9c"> ↵ </a></div>
    <div class="issue"> retry behavior should probably be specced a bit better.<a href="#issue-8272893c"> ↵ </a></div>

--- a/spec/index.html
+++ b/spec/index.html
@@ -51,7 +51,7 @@
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Background Synchronization</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2015-09-22">22 September 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2015-09-23">23 September 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -66,7 +66,7 @@
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright 
 and related or neighboring rights to this work. 
-In addition, as of 22 September 2015, 
+In addition, as of 23 September 2015, 
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from an existing specification document.  If so, those parts are instead covered by the license of the existing specification document. </p>
@@ -285,7 +285,7 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
           <li> Set <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> to <a data-link-type="dfn" href="#success">success</a>. 
          </ol>
         <li>
-          <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">Upon fulfillment</a> of <var>waitUntilPromise</var>, or if the script has been aborted by the <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm">termination</a> of the <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept">service worker</a>, perform the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+          <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection">Upon rejection</a> of <var>waitUntilPromise</var>, or if the script has been aborted by the <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm">termination</a> of the <a data-link-type="dfn" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept">service worker</a>, perform the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
          <ol>
           <li>
             If <var>registration</var>’s <a data-link-type="dfn" href="#registration-state">registration state</a> is <a data-link-type="dfn" href="#unregisteredwhilefiring">unregisteredWhileFiring</a>: 
@@ -418,6 +418,7 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">upon fulfillment</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection">upon rejection</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">waiting for all</a>
     </ul>
    <li>


### PR DESCRIPTION
Besides changing the tool used, this also rephrases some of the algorithms,
and tries to make some behavior more explicit.

spec/index.html is autogenerated from spec/index.bs using the bikeshed tool.

The new footer.include and default.css files should be temporary until we've
figure out what the corect template should be for whatever group this spec is
going to be developed in.